### PR TITLE
Add subpanel to coyoteimport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test.timeline*
 test.dag*
 git.hash
 *.csv
+*_dev*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+### 2.3.0
+### feature
+- added subpanel/diagnosis from csv into coyote-import. Enables displaying in coyote for diagnosis in list_samples.html
+
 ### 2.2.1
 ### Bugfix
 - wrong path for tumor in contamination, used normal-path instead

--- a/deploy_hopper_dev.sh
+++ b/deploy_hopper_dev.sh
@@ -1,6 +1,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-PIPELINE_DEST="/fs1/pipelines/SomaticPanelPipeline/"
+PIPELINE_DEST="/fs1/viktor/SomaticPanelPipeline/"
 DEST_HOST="rs-fs1.lunarc.lu.se"
 
 

--- a/main.nf
+++ b/main.nf
@@ -56,7 +56,7 @@ Channel
 
 Channel
     .fromPath(params.csv).splitCsv(header:true)
-    .map{ row-> tuple(row.group, row.type, row.clarity_sample_id, row.clarity_pool_id) }
+    .map{ row-> tuple(row.group, row.type, row.clarity_sample_id, row.clarity_pool_id, row.diagnosis) }
     .set { meta_coyote }
 
 Channel
@@ -1120,7 +1120,7 @@ process coyote {
 	tag "$group"
 
 	input:
-		set group, file(vcf),  type, lims_id, pool_id, id, cnv_type, \
+		set group, file(vcf),  type, lims_id, pool_id, diagnosis, id, cnv_type, \
 			file(cnvplot), tissue_c, lowcov_type, file(lowcov) from \
 			vcf_coyote.join(meta_coyote.groupTuple()).join(cnvplot_coyote.join(meta_cnvplot, by:[0,1,2]).groupTuple()).join(lowcov_coyote.groupTuple())
 
@@ -1148,6 +1148,7 @@ process coyote {
 		--vcf /access/${params.subdir}/vcf/${vcf} --id ${process_group} \\
 		--cnv /access/${params.subdir}/plots/${cnvplot[cnv_index]} \\
 		--clarity-sample-id ${lims_id[tumor_idx]} \\
+		--subpanel ${diagnosis[tumor_idx]} \\
 		--lowcov /access/${params.subdir}/QC/${lowcov[tumor_idx_lowcov]} \\
                 --build 38 \\
                 --gens ${group} \\


### PR DESCRIPTION
I have added meta-information to the coyote import process.

In the csv we get information about diagnosis of the sample. This information comes from the clarity export and has a translation.dict. For instance paired samples usually take the value hem, and unpaired samples can take different values, such as Riktad, MPN and KLL. 

This was done in an effort to support a the new function, the diagnosis-field which is presented in the list_samples.html (case overview). This will help geneticists to easier detect samples that require urgent interpretation.