### PR TITLE
Riktad paired diagnosis

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+### 2.3.1
+### enhancement/bugfix
+- diagnosis/subpanel would always take tumor-value. If "Riktad" diagnosis and paired, assign normal-sample diagnosis as this is the correct paired analysis diagnosis
+
 ### 2.3.0
 ### feature
 - added subpanel/diagnosis from csv into coyote-import. Enables displaying in coyote for diagnosis in list_samples.html

--- a/deploy_hopper_simple.sh
+++ b/deploy_hopper_simple.sh
@@ -1,6 +1,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-PIPELINE_DEST="/fs1/pipelines/SomaticPanelPipeline/"
+PIPELINE_DEST="/fs1/viktor/SomaticPanelPipeline/"
 DEST_HOST="rs-fs1.lunarc.lu.se"
 
 

--- a/main.nf
+++ b/main.nf
@@ -1138,8 +1138,12 @@ process coyote {
 		cnv_index = tumor_idx_cnv
 		tumor_idx_lowcov = lowcov_type.findIndexOf{ it == 'tumor' || it == 'T' }
 		process_group = group
+		diag = diagnosis[tumor_idx]
 		if( id.size() >= 2 ) {
 			process_group = group + 'p'
+			if (diagnosis[tumor_idx] == "Riktad") {
+				diag = diagnosis[normal_idx]
+			}
 		}
 
 
@@ -1148,7 +1152,7 @@ process coyote {
 		--vcf /access/${params.subdir}/vcf/${vcf} --id ${process_group} \\
 		--cnv /access/${params.subdir}/plots/${cnvplot[cnv_index]} \\
 		--clarity-sample-id ${lims_id[tumor_idx]} \\
-		--subpanel ${diagnosis[tumor_idx]} \\
+		--subpanel ${diag} \\
 		--lowcov /access/${params.subdir}/QC/${lowcov[tumor_idx_lowcov]} \\
                 --build 38 \\
                 --gens ${group} \\

--- a/main.nf
+++ b/main.nf
@@ -1133,6 +1133,7 @@ process coyote {
 
 	script:
 		tumor_idx = type.findIndexOf{ it == 'tumor' || it == 'T' }
+		normal_idx = type.findIndexOf{ it == 'normal' || it == 'N' }
 		tumor_idx_cnv = cnv_type.findIndexOf{ it == 'tumor' || it == 'T' }
 		normal_idx_cnv = cnv_type.findIndexOf{ it == 'normal' || it == 'N' }
 		cnv_index = tumor_idx_cnv


### PR DESCRIPTION
Added small if statement to use normal-diagnosis for paired samples with Tumor-diagnosis == Riktad

These tumor samples were run as unpaired, to be quickly analyzed for a small subset of genes. When normal sample has been grown and later sequenced it should be part of the full analysis with the proper diagnosis == Hem which the normal sample will have.