### PR TITLE
Reduce publication dsl1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 ## Changelog ##
+### 2.3.4
+### hotfix
+- reduced amount of bam-files published and therefore stored on backup
 
-## 2.3.3
+### 2.3.3
 - added more genes to mark for germlines for myeloid profile
 
 ### 2.3.2

--- a/main.nf
+++ b/main.nf
@@ -86,7 +86,7 @@ Channel
 
 
 process bwa_umi {
-	publishDir "${OUTDIR}/bam", mode: 'copy', overwrite: true
+	publishDir "${OUTDIR}/bam", mode: 'copy', overwrite: true, pattern '*umi.sort.bam*'
 	cpus params.cpu_all
 	memory '128 GB'
 	time '2h'
@@ -172,7 +172,6 @@ process bwa_align {
 
 
 process markdup {
-	publishDir "${OUTDIR}/bam", mode: 'copy', overwrite: true
 	cpus params.cpu_many
 	memory '64 GB'
 	time '1h'


### PR DESCRIPTION
hotfix, no need to for review. Accepting change

Reduced amount of data published from alignment. Only saving UMI-reduced bam-files. reducing amount of data on backup