### PR TITLE
Fix merging cnvs

### DIFF
--- a/configs/modules/call_cnv.config
+++ b/configs/modules/call_cnv.config
@@ -1,0 +1,9 @@
+process {
+    withName: '.*CNV_CALLING:JOIN_TUMOR' {
+        ext.args   = '--bnd_distance 2500'
+    }
+    withName: '.*CNV_CALLING:JOIN_NORMAL' {
+        ext.args   = '--bnd_distance 2500'
+    }
+
+}

--- a/configs/modules/fusions.config
+++ b/configs/modules/fusions.config
@@ -1,0 +1,6 @@
+process {
+    withName: '.*FUSIONS:JOIN_FUSIONS' {
+        ext.args   = '--bnd_distance 10'
+    }
+
+}

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -236,7 +236,7 @@ profiles {
       // PON // 
       params.PON_freebayes = "${params.refpath}/PARP_inhibv2-0/PON_freebayes_100_masked.snv"
       params.PON_vardict = "${params.refpath}/PARP_inhibv2-0/PON_vardict_100_masked.snv"
-      params.PON_tnscope = "${params.refpath}/PARP_inhibv2-0/PON_tnscope_100_masked.snv"
+      params.tnscope = false
     // ALIGNMENT //
     // FASTQ //
       params.sample_val = 50000000
@@ -403,6 +403,8 @@ profiles {
 includeConfig 'configs/modules/base.config'
 includeConfig 'configs/modules/align_sentieon.config'
 includeConfig 'configs/modules/call_snv.config'
+includeConfig 'configs/modules/call_cnv.config'
+includeConfig 'configs/modules/fusions.config'
 includeConfig 'configs/modules/create_cnv_pon.config'
 
 process {

--- a/modules/local/filters/main.nf
+++ b/modules/local/filters/main.nf
@@ -284,10 +284,8 @@ process BIOMARKERS_TO_JSON {
         msis = msis_idx >= 0 ? markers[msis_idx].collect {'--msi_s ' + it} : null
         msip = msip_idx >= 0 ? markers[msip_idx].collect {'--msi_p ' + it} : null
         hrd = hrd_idx >= 0 ? markers[hrd_idx].collect {'--hrd ' + it} : null
-		tmp = []
-		if (msis) { tmp = tmp + msis }
-		if (msip) { tmp = tmp + msip }
-		if (hrd) { tmp = tmp + hrd }
+		tmp = [msis, msip, hrd]
+		tmp = tmp - null
         command = tmp.join(' ')
 		"""
 		python /fs1/viktor/SomaticPanelPipeline_dsl2/bin/aggregate_biomarkers.py $command --out ${group}.bio.json --id $group
@@ -300,10 +298,8 @@ process BIOMARKERS_TO_JSON {
         msis = msis_idx >= 0 ? markers[msis_idx].collect {'--msi_s ' + it} : null
         msip = msip_idx >= 0 ? markers[msip_idx].collect {'--msi_p ' + it} : null
         hrd = hrd_idx >= 0 ? markers[hrd_idx].collect {'--hrd ' + it} : null
-        tmp = []
-		if (msis) { tmp = tmp + msis }
-		if (msip) { tmp = tmp + msip }
-		if (hrd) { tmp = tmp + hrd }
+		tmp = [msis, msip, hrd]
+		tmp = tmp - null
         command = tmp.join(' ')
 		"""
 		echo $command

--- a/modules/local/svdb/main.nf
+++ b/modules/local/svdb/main.nf
@@ -24,7 +24,7 @@ process SVDB_MERGE_PANEL {
         cnvkit = cnvkit_idx >= 0 ? vcfs[cnvkit_idx].collect {it + ':cnvkit ' } : null
         gatk = gatk_idx >= 0 ? vcfs[gatk_idx].collect {it + ':gatk ' } : null
         genefuse = genefuse_idx >= 0 ? vcfs[genefuse_idx].collect {it + ':genefuse ' } : null
-        tmp = manta + delly + gatk + cnvkit + genefuse
+        tmp = [manta, delly, gatk, cnvkit, genefuse]
         tmp = tmp - null
         vcfs_svdb = tmp.join(' ')
 
@@ -54,7 +54,7 @@ process SVDB_MERGE_PANEL {
         cnvkit = cnvkit_idx >= 0 ? vcfs[cnvkit_idx].collect {it + ':cnvkit ' } : null
         gatk = gatk_idx >= 0 ? vcfs[gatk_idx].collect {it + ':gatk ' } : null
         genefuse = genefuse_idx >= 0 ? vcfs[genefuse_idx].collect {it + ':genefuse ' } : null
-        tmp = manta + delly + gatk + cnvkit
+        tmp = [manta, delly, gatk, cnvkit]
         tmp = tmp - null
         vcfs_svdb = tmp.join(' ')
 

--- a/modules/local/svdb/main.nf
+++ b/modules/local/svdb/main.nf
@@ -9,7 +9,8 @@ process SVDB_MERGE_PANEL {
 	output:
 		tuple val(group), val(meta), file("${meta.id}.merged.vcf"), emit: merged_vcf
 
-	script:  
+	script:
+        def args = task.ext.args ?: ''  
         // for each sv-caller add idx, find vcf and find priority, add in priority order! //
         // index of vcfs added from mix //
         manta_idx = vcfs.findIndexOf{ it =~ 'manta' }
@@ -24,7 +25,7 @@ process SVDB_MERGE_PANEL {
         cnvkit = cnvkit_idx >= 0 ? vcfs[cnvkit_idx].collect {it + ':cnvkit ' } : null
         gatk = gatk_idx >= 0 ? vcfs[gatk_idx].collect {it + ':gatk ' } : null
         genefuse = genefuse_idx >= 0 ? vcfs[genefuse_idx].collect {it + ':genefuse ' } : null
-        tmp = [manta, delly, gatk, cnvkit, genefuse]
+        tmp = manta + delly + gatk + cnvkit + genefuse
         tmp = tmp - null
         vcfs_svdb = tmp.join(' ')
 
@@ -39,7 +40,7 @@ process SVDB_MERGE_PANEL {
         priority = tmpp.join(',')
     
         """
-        svdb --merge --vcf $vcfs_svdb --no_intra --pass_only --bnd_distance 10 --overlap 0.7 --priority $priority > ${meta.id}.merged.vcf
+        svdb --merge --vcf $vcfs_svdb --no_intra --pass_only $args --overlap 0.7 --priority $priority > ${meta.id}.merged.vcf
         """
     stub:
         manta_idx = vcfs.findIndexOf{ it =~ 'manta' }
@@ -54,7 +55,7 @@ process SVDB_MERGE_PANEL {
         cnvkit = cnvkit_idx >= 0 ? vcfs[cnvkit_idx].collect {it + ':cnvkit ' } : null
         gatk = gatk_idx >= 0 ? vcfs[gatk_idx].collect {it + ':gatk ' } : null
         genefuse = genefuse_idx >= 0 ? vcfs[genefuse_idx].collect {it + ':genefuse ' } : null
-        tmp = [manta, delly, gatk, cnvkit]
+        tmp = manta + delly + gatk + cnvkit
         tmp = tmp - null
         vcfs_svdb = tmp.join(' ')
 


### PR DESCRIPTION
Fix in place for merging CNVs. --bnd_distance was set too low. Fusions and CNV merging now have different rules set in configs but still use the same module-code.