### PR TITLE
Dsl2 hg38 ref fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ TODO.md
 *_test.config
 logs/
 bugs/
+.venv
+.env
+venv
+env

--- a/bin/find_contaminant.pl
+++ b/bin/find_contaminant.pl
@@ -115,7 +115,12 @@ while ( my $v = $vcf->next_var() ) {
 				$n_VAF = $gt->{VAF};
 			}
 			else {
-				$n_VAF = $min/$n_DP;
+				if ($n_DP == 0) {
+					$n_VAF = 0;
+				}
+				else {
+					$n_VAF = $min/$n_DP;
+				}
 			}
 			
 		}

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -248,7 +248,7 @@ profiles {
 
     // SNV CALLING //
     params.vardict_var_freq_cutoff_p  = '0.01'
-    params.vardict_var_freq_cutoff_up = '0.03'
+    params.vardict_var_freq_cutoff_up = '0.01'
     params.fb_var_freq_cutoff_p       = '0.03'
     params.fb_var_freq_cutoff_up      = '0.03'
     params.tnscope_var_freq_cutoff_p  = '0.0005'
@@ -323,7 +323,7 @@ profiles {
 
     // SNV CALLING //
     params.vardict_var_freq_cutoff_p  = '0.01'
-    params.vardict_var_freq_cutoff_up = '0.03'
+    params.vardict_var_freq_cutoff_up = '0.01'
     params.fb_var_freq_cutoff_p       = '0.03'
     params.fb_var_freq_cutoff_up      = '0.03'
     params.tnscope_var_freq_cutoff_p  = '0.0005'
@@ -402,7 +402,7 @@ profiles {
 
     // SNV CALLING //
     params.vardict_var_freq_cutoff_p  = '0.01'
-    params.vardict_var_freq_cutoff_up = '0.03'
+    params.vardict_var_freq_cutoff_up = '0.01'
     params.fb_var_freq_cutoff_p       = '0.03'
     params.fb_var_freq_cutoff_up      = '0.03'
     params.tnscope_var_freq_cutoff_p  = '0.0005'
@@ -491,14 +491,14 @@ profiles {
 
     // BED //
     params.regions_bed                = "${params.refpath}/bed/lymphoid-twist/v3/lymph_v3_mergedprobes_simple.bed"
-    params.interval_list              = "${params.refpath}/bed/lymphoid-twist/v3/lymph_v3_mergedprobes_simple.interval_list"
+    params.interval_list              = "${params.refpath}/bed/lymphoid-twist/v3/lymph_v3_mergedprobes_simple_masked.interval_list"
     params.regions_bed_qc             = "${params.refpath}/bed/lymphoid-twist/v3/lymph_v3_mergedprobes_simple.bed"
-    params.interval_list_qc           = "${params.refpath}/bed/lymphoid-twist/v3/lymph_v3_mergedprobes_simple.interval_list"
+    params.interval_list_qc           = "${params.refpath}/bed/lymphoid-twist/v3/lymph_v3_mergedprobes_simple_masked.interval_list"
     params.regions_proteincoding      ="${params.refpath}/bed/lymphoid-twist/v3/lymph_v3_mergedprobes_simple_coding.bed"
 
     // SNV CALLING //
     params.vardict_var_freq_cutoff_p  = '0.01'
-    params.vardict_var_freq_cutoff_up = '0.03'
+    params.vardict_var_freq_cutoff_up = '0.01'
     params.fb_var_freq_cutoff_p       = '0.03'
     params.fb_var_freq_cutoff_up      = '0.03'
     params.tnscope_var_freq_cutoff_p  = '0.0005'


### PR DESCRIPTION
- Fixed reference intervals for lymphoid panel.
- Now all the profiles should be able use hg38(masked) genome build
- Fixed zero division error