### PR TITLE
set time limit to 2hrs for genefuse

### DIFF
--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -371,7 +371,7 @@ profiles {
     params.panel_profile_name         = 'solid'
     // PATHS //
     params.outdir                     = "${params.resultsdir}${params.dev_suffix}"
-    params.subdir                     = 'solid_hg38_masked'
+    params.subdir                     = 'solid_hg38' // making it more compatible with the live version
     params.crondir                    = "${params.outdir}/cron/"
     params.gens_accessdir             = "/access/${params.subdir}/gens"
 

--- a/configs/nextflow.process.config
+++ b/configs/nextflow.process.config
@@ -16,4 +16,11 @@ process {
         maxErrors       = 5
     }
 
+    withName: GENEFUSE {
+        cpus            = 30
+        memory          = '90GB'
+        time            = '2h'
+        errorStrategy   = 'ignore'
+    }
+
 }

--- a/modules/local/genefuse/main.nf
+++ b/modules/local/genefuse/main.nf
@@ -1,6 +1,4 @@
 process GENEFUSE {
-    label 'process_very_high'
-    label 'error_ignore'
     tag "${meta.id}"
 
     input:


### PR DESCRIPTION
1. Reduced the time limit for genefuse to 2hours. If there is error, the pipeline will ignore it and move on
2. updated outdir for solid profile from solid_hg38_masked --> solid_hg38