### PR TITLE
corrected faulty header, needed for pysam

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+### ???
+### Patch
+- VAF in FORMAT field should be Float, not Integer
+
 ### 2.1.2
 ### Bugfix
 - cnvkit 0/0 genotypes wrongly was presented as 0/1

--- a/bin/aggregate_vcf.pl
+++ b/bin/aggregate_vcf.pl
@@ -44,7 +44,7 @@ sub print_header {
     print '##INFO=<ID=variant_callers,Number=.,Type=String,Description="List of variant callers which detected the variant">'."\n";
     print '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">'."\n";
     print '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">'."\n";
-    print '##FORMAT=<ID=VAF,Number=1,Type=Integer,Description="ALT allele observation fraction">'."\n";
+    print '##FORMAT=<ID=VAF,Number=1,Type=Float,Description="ALT allele observation fraction">'."\n";
     print '##FORMAT=<ID=VD,Number=1,Type=Integer,Description="ALT allele observation count">'."\n";
     foreach( @$filters ) {
 	print "##FILTER=<ID=$_,Description=\"$_\">\n";


### PR DESCRIPTION
Very small fix for aggregate_vcf.pl

Format field VAF was assigned as Integer but should be Float. This causes coyote_cli/pysam to throw and error