### PR TITLE
[PATCH] Output ISO 8601 /  JSON compliant dates in id SNP qc metadata

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 ## Changelog ##
 
+### dsl2-v1.1.4
+### patch 
+- Change date format in id SNP qc metadata to UTC / ISO 8601 format
+
+
 ### dsl2-v1.1.3
 ### update 
 - Idsnp qc for all Somatic panel pipelies

--- a/modules/local/idSnp/main.nf
+++ b/modules/local/idSnp/main.nf
@@ -85,7 +85,7 @@ process SNP_CHECK {
             cp s${tumor_id}_c${normal_id}.json  ${tumor_id}.json
             cp s${tumor_id}_c${normal_id}.json  ${normal_id}.json
             rm s${tumor_id}_c${normal_id}.json
-            today_date=\$(date +"%Y-%m-%d")
+            today_date=\$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
             echo '{"partner" : "${tumor_id}","sequencing_run" : "${tumor_seq_run}","analysis_date" : "'\${today_date}'" }' > ${normal_id}_partner_info.json
             echo '{"partner" : "${normal_id}","sequencing_run" : "${normal_seq_run}","analysis_date" : "'\${today_date}'" }' > ${tumor_id}_partner_info.json


### PR DESCRIPTION
Small patch to date saved in id snp qc metadata. The date is now saved in ISO 8601 / UTC-format. 

i.e. "2024-01-01" -> "2024-01-01T14:01:52.030Z"

The added granularity will also make it easier to easier discern which QC data is up-to-date if something is rerun the same day.