### PR TITLE
gens load fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 ## Changelog ##
 
+## v3.0.8
+## Gens Load Fix
+- added --case-id $group to the gens load command
+- if the sample is paired 'p' is appended to $group
+
 ### v3.0.7
 ### CNV artefact annotation
 - bugfix: cnv annotation json fix for manta variants (required for coyote3)

--- a/modules/local/cnvkit/main.nf
+++ b/modules/local/cnvkit/main.nf
@@ -263,6 +263,13 @@ process MERGE_GENS {
         task.ext.when == null || task.ext.when
     
     script:
+        process_group = group
+        tumor_idx = 0
+        tumor_idx_lowcov = 0
+        if( meta.id.size() >= 2 ) {
+            process_group = group + 'p'
+            tumor_idx = meta.type.findIndexOf{ it == 'tumor' || it == 'T' }
+        }
         def args     = task.ext.args ?: ""
         def prefix   = task.ext.prefix ?: "${meta.id}"
 
@@ -290,11 +297,11 @@ process MERGE_GENS {
             bedtools sort -i !{meta.id}.merged.baf.bed > !{meta.id}.merged.sorted.baf.bed
             bgzip !{meta.id}.merged.sorted.baf.bed
             tabix !{meta.id}.merged.sorted.baf.bed.gz
-            echo "gens load sample --sample-id !{meta.id} --genome-build 38 --baf !{params.gens_accessdir}/!{meta.id}.merged.sorted.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.merged.sorted.cov.bed.gz" > !{meta.id}.gens
+            echo "gens load sample --sample-id !{meta.id} --case-id !{process_group} --genome-build 38 --baf !{params.gens_accessdir}/!{meta.id}.merged.sorted.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.merged.sorted.cov.bed.gz" > !{meta.id}.gens
         else
             tabix !{meta.id}.full.baf.bed.gz
             tabix !{meta.id}.full.cov.bed.gz
-            echo "gens load sample --sample-id !{meta.id} --genome-build 38 --baf !{params.gens_accessdir}/!{meta.id}.full.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.full.cov.bed.gz" > !{meta.id}.gens
+            echo "gens load sample --sample-id !{meta.id} --case-id !{process_group} --genome-build 38 --baf !{params.gens_accessdir}/!{meta.id}.full.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.full.cov.bed.gz" > !{meta.id}.gens
         fi
 
         cat <<-END_VERSIONS > versions.yml
@@ -306,6 +313,13 @@ process MERGE_GENS {
         '''
 
     stub:
+        process_group = group
+        tumor_idx = 0
+        tumor_idx_lowcov = 0
+        if( meta.id.size() >= 2 ) {
+            process_group = group + 'p'
+            tumor_idx = meta.type.findIndexOf{ it == 'tumor' || it == 'T' }
+        }
         def prefix   = task.ext.prefix ?: "${meta.id}"
         """
         touch ${meta.id}.merged.sorted.cov.bed.gz 


### PR DESCRIPTION
    - added --case-id $group to the gens load command
    - if the sample is paired 'p' is appended to $group