### PR TITLE
override variant filteraton if override rules are provided

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 ## Changelog ##
 
+## v3.0.9
+## Variant Filtration
+- variants that are tagged as failed and are filtered by post_annotation_filtering.py will be kept if the user has provided the rules in the nectflow config as params.override_filter_terms 
+- Example way to addto the config file, Each Key=Value should be separated by a semicolon and the values within each key should be separated by a comma.
+  ```
+    params.override_filter_terms = "CLIN_SIG=likely_pathogenic,pathogenic;CANONICAL=Yes,Y"
+  ```
+
 ## v3.0.8
 ## Gens Load Fix
 - added --case-id $group to the gens load command

--- a/bin/post_annotation_filtering.py
+++ b/bin/post_annotation_filtering.py
@@ -4,6 +4,7 @@ from pprint import pprint
 import cmdvcf
 import argparse
 import fnmatch
+import re
 
 
 def filter_flags(var,filters):
@@ -21,7 +22,18 @@ def filter_flags(var,filters):
         return True
     
 
-def read_vcf(infile,filters,af_cutoff):
+def override_filters(var, override_filters) -> bool:
+    """
+    If a variant is tagged as failed but keeps it if additional key, value terms are provided for exmaple is `likely pathogenic and pathogenic` in CLIN_SIG are kept
+    """
+    for filter_key_values in override_filters:
+        for filter_key, filter_values in filter_key_values.items():
+            if filter_key in var["INFO"]["CSQ"][0]:
+                if any([value in var["INFO"]["CSQ"][0][filter_key] for value in filter_values]):
+                    return True, filter_key
+    return False, None
+
+def read_vcf(infile,filters,af_cutoff, override_key_values):
     """
     
     """
@@ -30,21 +42,36 @@ def read_vcf(infile,filters,af_cutoff):
     print(vcf_object.header,end="")
     
     for var in vcf_object.fetch():
+        override = False
         var_dict = cmdvcf.parse_variant(var,vcf_object.header)
         
         af_pass = check_gnomad_vaf(var_dict,af_cutoff)
         
         filter_pass = filter_flags(var_dict,filters)
+
+        if not filter_pass:
+            override, override_key = override_filters(var_dict, override_key_values)
+
+        if override:
+            current_filter_column = var_dict["FILTER"]
+
+            if "PASS" not in current_filter_column.split(";"):
+                new_filter_column = f"PASS;{override_key}_Override;{current_filter_column}"
+            else:
+                new_filter_column = f"{override_key}_Override;{current_filter_column}"
+
+            var = re.sub(current_filter_column, new_filter_column, str(var))
         
-        if af_pass and filter_pass:
+        if af_pass and (filter_pass or override):
             print(str(var),end="")
 
 
 def main():
     af_cutoff = 0.05
     filters = []
+    override_key_values = []
     
-    parser = argparse.ArgumentParser(description="This is a script to filter variants before loading into coyote. This can be based upon gnomad frequencies and filter flags")
+    parser = argparse.ArgumentParser(description="his is a script to filter variants before loading into coyote. This can be based upon gnomad frequencies and filter flags. This will not filter out variants that are tagged as failed but are `likely pathogenic and pathogenic`.")
 
     parser.add_argument(
         "--vcf",
@@ -63,13 +90,25 @@ def main():
         type=str,
         help="comma-separated list of filters to NOT keep"
     )
+    parser.add_argument(
+        "--override_key_values",
+        type=str,
+        help="semiclon-separated list of terms to keep if the variant is not passed by the filters, eg: 'CLIN_SIG=likely_pathogenic,pathogenic;CANONICAL=Yes,Y'"
+    )
     args = parser.parse_args()
     if args.filters is not None:
         filters = args.filters.split(',')
     if args.max_freq is not None:
         af_cutoff = args.max_freq
+
+    if args.override_key_values:
+        override_key_values = [
+            {kv.split('=')[0]: kv.split('=')[1].split(',')}
+            for kv in args.override_key_values.split(';')
+            if kv
+        ]
     
-    read_vcf(args.vcf,filters,af_cutoff)
+    read_vcf(args.vcf,filters,af_cutoff, override_key_values)
     
 
 def check_gnomad_vaf(var,af_cutoff):

--- a/configs/modules/snv_annotate.config
+++ b/configs/modules/snv_annotate.config
@@ -114,6 +114,6 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
 
-        ext.args    = { "--max_freq ${params.filter_freq} --filters ${params.filter_field_filter}" }
+        ext.args    = { "--max_freq ${params.filter_freq} --filters ${params.filter_field_filter} --override_key_values ${params.override_filter_terms}" }
     }
 }

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -76,6 +76,7 @@ params {
   // SNV filters //
   filter_field_filter                 = "FAIL_PON*,FAIL_NVAF,FAIL_LONGDEL"
   filter_freq                         = 0.05
+  override_filter_terms               = "CLIN_SIG=likely_pathogenic,pathogenic" // comma separated Key,values
 
   // ALIGNMENT //
   sentieon_bwa                        = true


### PR DESCRIPTION
## Fix
The new implementation introduces an override mechanism that allows users to bypass certain variant filtering rules if they provide specific override terms in the Nextflow config (params.override_filter_terms).

### How it Works:
- Variants that fail the filtering criteria in post_annotation_filtering.py can be retained if they match the override rules specified by the user.
- The override rules are provided as key-value pairs, where:
  - Each key-value pair is separated by a semicolon ( ; ).
  - Multiple values for a key are separated by a comma ( , ).

- Example:
  ```
  params.override_filter_terms = "CLIN_SIG=likely_pathogenic,pathogenic;CANONICAL=Yes,Y"
  ```
- This means that any variant with CLIN_SIG=likely_pathogenic or pathogenic will not be filtered out, even if it fails other filtering criteria.
- This will also add `PASS` tag along with an additional tag due to which the variant has been retained (eg. `CLINC_SIG_Override`)

- Currently, we are only overriding if the CLIN_SIG=likely_pathogenic or pathogenic