### PR TITLE
d4tools path was overwritten by loading home-dir for worker

### DIFF
--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -3,7 +3,7 @@
 
 singularity{
   enabled                             = true	
-  runOptions                          = '--bind /fs1/ --bind /local/ --bind /fs2/ --bind /mnt/beegfs/'
+  runOptions                          = '--bind /fs1/ --bind /local/ --bind /fs2/ --bind /mnt/beegfs/ --no-home' 
 }
 
 env{


### PR DESCRIPTION
nextflow is adding /home/$user in path. When run as worker this overrides the path to d4tools which was installed in /home/worker/libs/... in the container. By adding the --no-home run_option for singularity in the config this is avoided.
