### PR TITLE
Sp fix tnscope parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.0.18
+- added tnscope parameters to find snvs only
+
 ## 3.0.17
 - reverted clinsig rescue for failed variants
 

--- a/configs/modules/snv_calling.config
+++ b/configs/modules/snv_calling.config
@@ -40,6 +40,7 @@ process {
         ext.args2   = [                                     // For other paramters
             "--clip_by_minbq 1",
             "--max_error_per_read 3",
+            "-disable_detector sv",
             "--min_init_tumor_lod 2.0",
             "--min_base_qual 10",
             "--min_base_qual_asm 10",

--- a/configs/modules/snv_calling.config
+++ b/configs/modules/snv_calling.config
@@ -40,7 +40,7 @@ process {
         ext.args2   = [                                     // For other paramters
             "--clip_by_minbq 1",
             "--max_error_per_read 3",
-            "-disable_detector sv",
+            "--disable_detector sv",
             "--min_init_tumor_lod 2.0",
             "--min_base_qual 10",
             "--min_base_qual_asm 10",


### PR DESCRIPTION
Tnscope adds SVs variants that might cause downstream analysis problematic. Added --disable_detector sv to make sure we only detect snv and small indels in tnscope variant calls.