### PR TITLE
use first element of gatk copy number, handles merged variants

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.1.3
+- cnvJSON.py could not handle merged GATK variants, now asumes copy number to be the same for merged
+
 ## 3.1.2
 - gmshem to downsample at 100 mbp
 - coyote-yaml renamed and always saved in non-cron dir

--- a/bin/cnvJSON.py
+++ b/bin/cnvJSON.py
@@ -145,7 +145,8 @@ def get_varinfo(info,gt):
     if "FOLD_CHANGE_LOG" in info:
         varinfo["ratio"] = float(info["FOLD_CHANGE_LOG"])
     elif "gatkCN" in info:
-        varinfo["ratio"] = float(int(info["gatkCN"])/2)
+        gatkcn = info['gatkCN'].split(',')[0]
+        varinfo["ratio"] = float(int(gatkcn)/2)
     elif "SVTYPE" in info:
         if info["SVTYPE"] == "DEL":
             varinfo["ratio"] = "DEL"


### PR DESCRIPTION
Fixes recent crashes for normal gatk called variants that was merged.

cnvJSON.py could not handle lists for caused by merging close by variants of same CN.

Now checks for list and takes first element as int