### PR TITLE
gens baf data fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.1.4
+- generate_gens_data_from_cnvkit.pl no longer uses deprecated AD-field from freebayes
+
 ## 3.1.3
 - cnvJSON.py could not handle merged GATK variants, now asumes copy number to be the same for merged
 

--- a/bin/generate_gens_data_from_cnvkit.pl
+++ b/bin/generate_gens_data_from_cnvkit.pl
@@ -30,12 +30,9 @@ while ( my $var = $vcf->next_var() ) {
     for my $gt (@{$var->{GT}}) {
 	next unless $gt->{_sample_id} eq $sample_id;
 	my $DP = ($gt->{DP} or 0);
-	last if $DP < 100 or !$gt->{AD};
-
-	my @AD = split /,/, $gt->{AD};
-	last unless @AD == 2;
-
-	my $vaf = $AD[1]/$gt->{DP};
+	last if $DP < 100 or !$gt->{AO};
+	my $AD = $gt->{AO};
+	my $vaf = $AD/$gt->{DP};
 	push @baf_data, $var->{CHROM}."\t".($var->{POS}-1)."\t".$var->{POS}."\t".$vaf;
     }
     


### PR DESCRIPTION
When replacing vt-tools with bcftools I removed AD-field from freebayes

This caused baf-generation to fault. Now the script uses AO-field instead