### PR TITLE
CNV as JSON and optional multiple SVDB annotations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Changelog ##
 
+## 3.1.6
+- CNVs as JSON. Updated import script to ol'coyote to support this. 
+- Added multiple SVDB annotations via config-map
+
 ## 3.1.5
 - added more meta information to the coyote3 load yaml and legacy coyote
 

--- a/bin/cnvJSON.py
+++ b/bin/cnvJSON.py
@@ -158,10 +158,12 @@ def get_varinfo(info,gt):
         varinfo["PR"] = gt["PR"]
     if "SR" in gt:
         varinfo["SR"] = gt["SR"]
-    if "ACOUNT" in info:
-        varinfo["ACOUNT"] = int(info["ACOUNT"])
-    if "AFRQ" in info:
-        varinfo["AFRQ"] = float(info["AFRQ"])
+    # Dynamically capture any AFRQ* and ACOUNT* keys
+    for key, value in info.items():
+        if key.startswith("AFRQ"):
+            varinfo[key] = float(value)
+        elif key.startswith("ACOUNT"):
+            varinfo[key] = int(value)
     return varinfo
 
 def gt_field(gt_keys,gt_values):

--- a/configs/modules/cnv_annotate.config
+++ b/configs/modules/cnv_annotate.config
@@ -110,7 +110,7 @@ process {
             overwrite: true,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        ext.args    = { "--bnd_distance 25000 --overlap 0.7 --in_occ Obs --out_occ ACOUNT --in_frq Frq --out_frq AFRQ --db ${params.loqusdb_export}" }
+        ext.args    = { "--bnd_distance 25000 --overlap 0.7 --in_occ Obs  --in_frq Frq" }
     }
 
 }

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -474,7 +474,12 @@ profiles {
 
     // CNV CALLING //
     params.panel_cna                  = "${params.refpath}/solid/all_solid.cna"
-    params.loqusdb_export             = "${params.refpath}/solid/loqusdb_export_solid_curated.vcf"
+    params.loqusdb_export             = true
+    params.loqusdb_vcfs               = [
+                                          ALL: "${params.refpath}solid/solid_all_251009_5p.vcf",
+                                          GC: "${params.refpath}/solid/solid_gc_251009_5p.vcf",
+                                          AT: "${params.refpath}/solid/solid_at_251009_5p.vcf"
+                                        ]
 
     // MANTA //
     params.bedgz                      = "${params.refpath}/bed/twist-st/pool1_padded20bp.bed.gz"

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -44,7 +44,7 @@ process COYOTE {
 
         // find what to load into coyote, depending on what files are in $import //
         // index of imports added from mix //
-        cnvseg_idx     = importy.findIndexOf{ it =~ 'panel' }
+        cnvseg_idx     = importy.findIndexOf{ it =~ 'cnvs' }
         fusions_idx    = importy.findIndexOf{ it =~ 'annotated' }
         biomarkers_idx = importy.findIndexOf{ it =~ 'bio' }
         lowcov_idx     = importy.findIndexOf{ it =~ 'lowcov' }

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -136,7 +136,7 @@ process COYOTE {
         tumor_sample = meta.id[tumor_idx]
         // find what to load into coyote, depending on what files are in $import //
         // index of imports added from mix //
-        cnvseg_idx     = importy.findIndexOf{ it =~ 'panel' }
+        cnvseg_idx     = importy.findIndexOf{ it =~ 'cnvs' }
         fusions_idx    = importy.findIndexOf{ it =~ 'annotated' }
         biomarkers_idx = importy.findIndexOf{ it =~ 'bio' }
         lowcov_idx     = importy.findIndexOf{ it =~ 'lowcov' }

--- a/modules/local/svdb/main.nf
+++ b/modules/local/svdb/main.nf
@@ -141,7 +141,8 @@ process SVDB_ANNOTATE_ARTEFACTS {
     tag "$group"
 
     input:
-        tuple val(group), val(meta), file(vcf), val(db_name), file(db_vcf)
+        tuple val(group), val(meta), file(vcf)
+	val(dbs)
         
     output:
         tuple val(group), val(meta), file("${meta.id}.cnv.artefacts.vcf"),  emit: artefacts
@@ -151,26 +152,79 @@ process SVDB_ANNOTATE_ARTEFACTS {
         task.ext.when == null || task.ext.when
 
     script:
-        def args = task.ext.args ?: ''
-        def prefix = task.ext.prefix ?: "${meta.id}" 
-        """
-        svdb --query $args -out_frq AFRQ_${db_name} --out_occ ACOUNT_${db_name} --db ${db_vcf} --query_vcf $vcf > ${meta.id}.cnv.artefacts.vcf
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            svdb: \$( echo \$(svdb) | head -1 | sed 's/usage: SVDB-\\([0-9]\\.[0-9]\\.[0-9]\\).*/\\1/' )
-        END_VERSIONS
-        """
-
-    stub:
+        def args   = task.ext.args ?: ''
         def prefix = task.ext.prefix ?: "${meta.id}"
-        """
-        echo "-db $params.loqusdb_export --query_vcf $vcf $db_name $db_vcf" > ${meta.id}.cnv.artefacts.vcf
 
+        // 🧠 Build the sequential svdb chain as a bash loop
+        // We generate bash code dynamically in Groovy, then insert it below.
+        def svdb_chain = dbs.collect { db_name, db_vcf ->
+            """
+            echo "[SVDB] Annotating with ${db_name} (${db_vcf})"
+            svdb --query ${args} \\
+                 --out_frq AFRQ_${db_name} \\
+                 --out_occ ACOUNT_${db_name} \\
+                 --db ${db_vcf} \\
+                 --query_vcf "\$input_vcf" \\
+                 > tmp_${db_name}.vcf
+            input_vcf="tmp_${db_name}.vcf"
+            """
+        }.join("\n\n")
+
+        // 🧱 Emit final bash script
+        return """
+        set -euo pipefail
+
+        # Start from the original input VCF
+        input_vcf="${vcf}"
+
+        # Sequentially annotate using all DBs
+        ${svdb_chain}
+
+        # Final output file
+        mv "\$input_vcf" "${meta.id}.cnv.artefacts.vcf"
+
+        # Version tracking
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            svdb: \$( echo \$(svdb) | head -1 | sed 's/usage: SVDB-\\([0-9]\\.[0-9]\\.[0-9]\\).*/\\1/' )
+            svdb: \$( svdb 2>&1 | head -1 | sed 's/usage: SVDB-\\([0-9]\\.[0-9]\\.[0-9]\\).*/\\1/' )
         END_VERSIONS
         """
+    stub:
+        def args   = task.ext.args ?: ''
+        def prefix = task.ext.prefix ?: "${meta.id}"
 
+        // 🧠 Build the sequential svdb chain as a bash loop
+        // We generate bash code dynamically in Groovy, then insert it below.
+        def svdb_chain = dbs.collect { db_name, db_vcf ->
+            """
+            echo "[SVDB] Annotating with ${db_name} (${db_vcf})"
+            echo --query ${args} \\
+                 --out_frq AFRQ_${db_name} \\
+                 --out_occ ACOUNT_${db_name} \\
+                 --db ${db_vcf} \\
+                 --query_vcf "\$input_vcf" \\
+                 > tmp_${db_name}.vcf
+            input_vcf="tmp_${db_name}.vcf"
+            """
+        }.join("\n\n")
+
+        // 🧱 Emit final bash script
+        return """
+        set -euo pipefail
+
+        # Start from the original input VCF
+        input_vcf="${vcf}"
+
+        # Sequentially annotate using all DBs
+        ${svdb_chain}
+
+        # Final output file
+        mv "\$input_vcf" "${meta.id}.cnv.artefacts.vcf"
+
+        # Version tracking
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            svdb: \$( svdb 2>&1 | head -1 | sed 's/usage: SVDB-\\([0-9]\\.[0-9]\\.[0-9]\\).*/\\1/' )
+        END_VERSIONS
+        """
 }

--- a/modules/local/svdb/main.nf
+++ b/modules/local/svdb/main.nf
@@ -155,7 +155,7 @@ process SVDB_ANNOTATE_ARTEFACTS {
         def args   = task.ext.args ?: ''
         def prefix = task.ext.prefix ?: "${meta.id}"
 
-        // 🧠 Build the sequential svdb chain as a bash loop
+        // Build the sequential svdb chain as a bash loop
         // We generate bash code dynamically in Groovy, then insert it below.
         def svdb_chain = dbs.collect { db_name, db_vcf ->
             """
@@ -170,7 +170,7 @@ process SVDB_ANNOTATE_ARTEFACTS {
             """
         }.join("\n\n")
 
-        // 🧱 Emit final bash script
+        // Emit final bash script
         return """
         set -euo pipefail
 
@@ -193,7 +193,7 @@ process SVDB_ANNOTATE_ARTEFACTS {
         def args   = task.ext.args ?: ''
         def prefix = task.ext.prefix ?: "${meta.id}"
 
-        // 🧠 Build the sequential svdb chain as a bash loop
+        // Build the sequential svdb chain as a bash loop
         // We generate bash code dynamically in Groovy, then insert it below.
         def svdb_chain = dbs.collect { db_name, db_vcf ->
             """
@@ -208,7 +208,7 @@ process SVDB_ANNOTATE_ARTEFACTS {
             """
         }.join("\n\n")
 
-        // 🧱 Emit final bash script
+        // Emit final bash script
         return """
         set -euo pipefail
 

--- a/modules/local/svdb/main.nf
+++ b/modules/local/svdb/main.nf
@@ -141,7 +141,7 @@ process SVDB_ANNOTATE_ARTEFACTS {
     tag "$group"
 
     input:
-        tuple val(group), val(meta), file(vcf)
+        tuple val(group), val(meta), file(vcf), val(db_name), file(db_vcf)
         
     output:
         tuple val(group), val(meta), file("${meta.id}.cnv.artefacts.vcf"),  emit: artefacts
@@ -154,7 +154,7 @@ process SVDB_ANNOTATE_ARTEFACTS {
         def args = task.ext.args ?: ''
         def prefix = task.ext.prefix ?: "${meta.id}" 
         """
-        svdb --query $args --query_vcf $vcf > ${meta.id}.cnv.artefacts.vcf
+        svdb --query $args -out_frq AFRQ_${db_name} --out_occ ACOUNT_${db_name} --db ${db_vcf} --query_vcf $vcf > ${meta.id}.cnv.artefacts.vcf
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -165,7 +165,7 @@ process SVDB_ANNOTATE_ARTEFACTS {
     stub:
         def prefix = task.ext.prefix ?: "${meta.id}"
         """
-        echo "-db $params.loqusdb_export --query_vcf $vcf" > ${meta.id}.cnv.artefacts.vcf
+        echo "-db $params.loqusdb_export --query_vcf $vcf $db_name $db_vcf" > ${meta.id}.cnv.artefacts.vcf
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/subworkflows/local/add_to_db.nf
+++ b/subworkflows/local/add_to_db.nf
@@ -29,7 +29,7 @@ workflow ADD_TO_DB {
             }
         }.set { cnvkit_png }
 
-        optional = lc.mix(segments,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
+        optional = lc.mix(s_json,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
         optional_json = lc_d4.mix(s_json,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
         COYOTE { vcf.join(optional) }
         COYOTE_YAML { vcf.join(optional_json) }

--- a/subworkflows/local/cnv_annotate.nf
+++ b/subworkflows/local/cnv_annotate.nf
@@ -17,15 +17,10 @@ workflow CNV_ANNOTATE {
 		ch_versions = Channel.empty()
 
 		if (params.loqusdb_export) {
-			annotated_ch = tumor_ch
-			params.loqusdb_vcfs.each { db_name, db_path ->
-				annotated_ch = annotated_ch.map { group, meta, vcf ->
-					tuple(group, id, vcf, db_name, file(db_path))
-				}
-				annotated_ch = SVDB_ANNOTATE_ARTEFACTS(annotated_ch)
-			}
-			gene_input = annotated_ch
+			SVDB_ANNOTATE_ARTEFACTS(tumor, params.loqusdb_vcfs)
+			gene_input = SVDB_ANNOTATE_ARTEFACTS.out.artefacts
 		}
+
 		else {
 			gene_input = tumor.mix(normal)
 		}

--- a/subworkflows/local/cnv_annotate.nf
+++ b/subworkflows/local/cnv_annotate.nf
@@ -17,7 +17,12 @@ workflow CNV_ANNOTATE {
 		ch_versions = Channel.empty()
 
 		if (params.loqusdb_export) {
-			SVDB_ANNOTATE_ARTEFACTS ( tumor.mix(normal) )
+			Channel
+    			.from(params.vcfs)
+    			.map { name, vcf -> tuple(name, file(vcf)) }
+    			.set { vcf_ch }
+			
+			SVDB_ANNOTATE_ARTEFACTS ( tumor.combine(vcf_ch).view() )
 			gene_input = SVDB_ANNOTATE_ARTEFACTS.out.artefacts
 		}
 		else {

--- a/subworkflows/local/cnv_annotate.nf
+++ b/subworkflows/local/cnv_annotate.nf
@@ -18,7 +18,7 @@ workflow CNV_ANNOTATE {
 
 		if (params.loqusdb_export) {
 			SVDB_ANNOTATE_ARTEFACTS(tumor, params.loqusdb_vcfs)
-			gene_input = SVDB_ANNOTATE_ARTEFACTS.out.artefacts
+			gene_input = SVDB_ANNOTATE_ARTEFACTS.out.artefacts.mix(normal)
 		}
 
 		else {


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary
This PR aims to move all CNVs to JSON format. Also add frequency databases to CNVs via SVDB. These can be added as many as you define in config-map

This is done together with an update to Coyote that will present these frequencies in table

---

## Type of change
- [ ] Bug fix  
- [ ] Patch / hotfix  
- [x] New feature / enhancement  
- [ ] Refactor / cleanup  
- [ ] Documentation update  


---

## Checklist (author)  

- [x] **CHANGELOG** updated with a clear entry   
- [ ] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [x] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [x] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [x] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)  
- [x] New data formats tested for compatibility with **Coyote3**  
- [x] New data formats tested for compatibility with **GENS**  
- [x] Documentation updated (README, params, examples, usage)  
- [x] Containers / tools updated are version-pinned and reproducible  
- [ ] At least one reviewer has tested and approved the code  

---

## Breaking changes
- [x] No breaking changes  
- [ ] Params/outputs/configs changed (list details in **Summary**)  
- [ ] Output filenames or structure changed (document migration path)  

---

## Testing performed
All live profiles tested and confirmed to work. Both for paired and unpaired.

Performed by:  
- [x] Viktor  
- [ ] Ram  
- [ ] Sailedra 

---

## Notes for reviewers
Check for unclear nextflow code 

---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [x] Sailedra  

---

## Release notes (draft)
* Multiple SVDB frequency annotations
* CNVs as JSON import via perl-script
