### PR TITLE
Fix GENS v4 file loading to use data files instead of index files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.1.11
+- Fix: GENS v4 process attempted to load index files (e.g. .tbi) instead of the actual data files; corrected the load command to use the proper GENS v4 output files to prevent downstream failures.
+
 ## 3.1.10
 - Gens v4 output file name changed from `.gens_v4` -> `.gens_v4_somatic`
 

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -733,7 +733,7 @@ manifest {
     description     = 'call and annoate variants from WGS/WES of cancer patients'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version         = '3.1.10'
+    version         = '3.1.11'
 }
 
 // Include necessary configs

--- a/modules/local/cnvkit/main.nf
+++ b/modules/local/cnvkit/main.nf
@@ -256,6 +256,7 @@ process MERGE_GENS {
 
     output:
         tuple val(group), val(meta), file("*baf.bed.gz*"), file("*cov.bed.gz*"), optional: true,    emit: merged_gens
+        tuple val(group), val(meta), file("*baf.bed.gz"), file("*cov.bed.gz"),   optional: true,    emit: merged_gens_for_v4
         tuple val(group), val(meta), file("*.gens"),                                                emit: dbload
         path "versions.yml",                                                                        emit: versions
 

--- a/subworkflows/local/cnv_calling.nf
+++ b/subworkflows/local/cnv_calling.nf
@@ -106,7 +106,7 @@ workflow CNV_CALLING {
         }
 
         // GENS V4 output
-        GENS_V4 ( MERGE_GENS.out.merged_gens )
+        GENS_V4 ( MERGE_GENS.out.merged_gens_for_v4 )
 
         ///////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary
Fix GENS v4 file loading to use data files instead of index files

---

## Type of change
- [x] Bug fix  
- [x] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] Refactor / cleanup  
- [ ] Documentation update  


---

## Checklist (author)  

- [x] **CHANGELOG** updated with a clear entry   
- [x] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [ ] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [ ] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [ ] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)  
- [ ] New data formats tested for compatibility with **Coyote3**  
- [ ] New data formats tested for compatibility with **GENS**  
- [ ] Documentation updated (README, params, examples, usage)  
- [ ] Containers / tools updated are version-pinned and reproducible  
- [ ] At least one reviewer has tested and approved the code  

---

## Breaking changes
- [x] No breaking changes  
- [ ] Params/outputs/configs changed (list details in **Summary**)  
- [ ] Output filenames or structure changed (document migration path)  

---

## Testing performed
Tested by loading a sample into gens

Performed by:  
- [ ] Viktor  
- [x] Ram  
- [ ] Sailedra  

(Add if missing)

---

## Review performed by
- [x] Viktor  
- [ ] Ram  
- [ ] Sailedra  

(Add if missing)
