### PR TITLE
GENS_V4 process is removed and the command is added MERGE_GENS process

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.1.12
+- Fix: `GENS_V4` process removed and moved the command to generate `.gens_v4_somatic` file to `MERGE_GENS` process
+
 ## 3.1.11
 - Fix: GENS v4 process attempted to load index files (e.g. .tbi) instead of the actual data files; corrected the load command to use the proper GENS v4 output files to prevent downstream failures.
 

--- a/configs/modules/cnv_calling.config
+++ b/configs/modules/cnv_calling.config
@@ -140,14 +140,6 @@ process {
                 overwrite: true,
                 pattern: '*.gens',
             ],
-        ]
-
-    }
-
-    withName: '.*CNV_CALLING:GENS_V4' {
-        container = "${params.container_dir}/SomaticPanelPipeline_2021-06-24.sif"
-
-        publishDir = [
             [ 
                 path: "${params.outdir}/cron/gens",
                 mode: 'copy',
@@ -155,6 +147,7 @@ process {
                 pattern: '*.gens_v4_somatic',
             ],
         ]
+
     }
 
     withName: '.*CNV_CALLING:GATKCOV_BAF' {

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -733,7 +733,7 @@ manifest {
     description     = 'call and annoate variants from WGS/WES of cancer patients'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version         = '3.1.11'
+    version         = '3.1.12'
 }
 
 // Include necessary configs

--- a/subworkflows/local/cnv_calling.nf
+++ b/subworkflows/local/cnv_calling.nf
@@ -6,7 +6,6 @@ include { CNVKIT_PLOT                          } from '../../modules/local/cnvki
 include { CNVKIT_CALL                          } from '../../modules/local/cnvkit/main'
 include { CNVKIT_CALL as CNVKIT_CALL_TC        } from '../../modules/local/cnvkit/main'
 include { MERGE_GENS                           } from '../../modules/local/cnvkit/main'
-include { GENS_V4                              } from '../../modules/local/cnvkit/main'
 include { CNVKIT_BATCH as CNVKIT_BACKBONE      } from '../../modules/local/cnvkit/main'
 include { CNVKIT_BATCH as CNVKIT_EXONS         } from '../../modules/local/cnvkit/main'
 include { GATKCOV_BAF                          } from '../../modules/local/GATK/main'
@@ -105,9 +104,6 @@ workflow CNV_CALLING {
             CNVKIT_VCF_TUMOR = cnvkit_vcf.join(meta.filter( it -> it[1].type == "T" ) ).map{ val-> tuple(val[0], val[3], val[2] ) }
         }
 
-        // GENS V4 output
-        GENS_V4 ( MERGE_GENS.out.merged_gens_for_v4 )
-
         ///////////////////////////////////////////////////////////////////////////////////////
 
         //////////////////////////// GATK SEGMENT CALLING /////////////////////////////////////
@@ -180,7 +176,7 @@ workflow CNV_CALLING {
         tumor_vcf   =   JOIN_TUMOR.out.merged_vcf       // channel: [ val(group), val(vc), file(tumor.merged.vcf) ]
         normal_vcf  =   JOIN_NORMAL.out.merged_vcf      // channel: [ val(group), val(vc), file(normal.merged.vcf) ]
         gens        =   MERGE_GENS.out.dbload           // channel: [ val(group), val(meta), file(gens) ]
-        gens_v4     =   GENS_V4.out.dbload_v4           // channel: [ val(group), val(meta), file(gens_v4) ]
+        gens_v4     =   MERGE_GENS.out.gens_v4          // channel: [ val(group), val(meta), file(gens_v4) ]
         versions    =   ch_versions                     // channel: [ file(versions) ]
 
 }


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary

The GENS_V4 process is removed, and its command is added to the MERGE_GENS process. When cnvkit_split is false, the input files to the merge_gens process become the output files. This creates an empty output channel for the GENS_V4 process, so GENS_V4 does not receive any input files and is therefore skipped.  

---

## Type of change
- [x] Bug fix  
- [x] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] Refactor / cleanup  
- [ ] Documentation update  


---

## Checklist (author)  

- [x] **CHANGELOG** updated with a clear entry   
- [x] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [x] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [x] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [x] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)  
- [x] New data formats tested for compatibility with **Coyote3**  
- [x] New data formats tested for compatibility with **GENS**  
- [ ] Documentation updated (README, params, examples, usage)  
- [ ] Containers / tools updated are version-pinned and reproducible  
- [x] At least one reviewer has tested and approved the code  

---

## Breaking changes
- [x] No breaking changes  
- [ ] Params/outputs/configs changed (list details in **Summary**)  
- [ ] Output filenames or structure changed (document migration path)  

---

## Testing performed
Tested both on stub run and actual sample.

Performed by:  
- [ ] Viktor  
- [x] Ram  
- [ ] Sailedra  

---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [x] Sailedra  