### PR TITLE
fixed gens command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.1.14
+- Fixed Gens command where `!` is printed in the filename and ids in the command.
+
 ## 3.1.13
 - Fix: Markgermline now takes the severe consequences from annotation VEP.
 - Updated likely_benign clinvar in solid_mg.json file

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -733,7 +733,7 @@ manifest {
     description     = 'call and annoate variants from WGS/WES of cancer patients'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version         = '3.1.13'
+    version         = '3.1.14'
 }
 
 // Include necessary configs

--- a/modules/local/cnvkit/main.nf
+++ b/modules/local/cnvkit/main.nf
@@ -298,13 +298,13 @@ process MERGE_GENS {
             tabix !{meta.id}.merged.sorted.baf.bed.gz
             echo "gens load sample --sample-id !{meta.id} --case-id !{process_group} --genome-build 38 --baf !{params.gens_accessdir}/!{meta.id}.merged.sorted.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.merged.sorted.cov.bed.gz" > !{meta.id}.gens
 
-            echo "gens load sample --sample-id !${meta.id} --case-id !${process_group} --genome-build 38 --sample-type !${meta.type} --baf !{params.gens_accessdir}/!{meta.id}.merged.sorted.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.merged.sorted.cov.bed.gz" > !${meta.id}.gens_v4_somatic
+            echo "gens load sample --sample-id !{meta.id} --case-id !{process_group} --genome-build 38 --sample-type !{meta.type} --baf !{params.gens_accessdir}/!{meta.id}.merged.sorted.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.merged.sorted.cov.bed.gz" > !{meta.id}.gens_v4_somatic
         else
             tabix !{meta.id}.full.baf.bed.gz
             tabix !{meta.id}.full.cov.bed.gz
             echo "gens load sample --sample-id !{meta.id} --case-id !{process_group} --genome-build 38 --baf !{params.gens_accessdir}/!{meta.id}.full.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.full.cov.bed.gz" > !{meta.id}.gens
 
-            echo "gens load sample --sample-id !${meta.id} --case-id !${process_group} --genome-build 38 --sample-type !${meta.type} --baf !{params.gens_accessdir}/!{meta.id}.full.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.full.cov.bed.gz" > !${meta.id}.gens_v4_somatic
+            echo "gens load sample --sample-id !{meta.id} --case-id !{process_group} --genome-build 38 --sample-type !{meta.type} --baf !{params.gens_accessdir}/!{meta.id}.full.baf.bed.gz --coverage !{params.gens_accessdir}/!{meta.id}.full.cov.bed.gz" > !{meta.id}.gens_v4_somatic
         fi
 
         cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary  

There is an unnecessary `$` symbol in the gens command, which caused output files to be created with a `!` prefix instead of the expected filename.

---

## Type of change
- [x] Bug fix  
- [x] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] Refactor / cleanup  
- [ ] Documentation update  


---

## Checklist (author)  

- [x] **CHANGELOG** updated with a clear entry   
- [x] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [x] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [x] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [x] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)  
- [ ] New data formats tested for compatibility with **Coyote3**  
- [ ] New data formats tested for compatibility with **GENS**  
- [ ] Documentation updated (README, params, examples, usage)  
- [ ] Containers / tools updated are version-pinned and reproducible  
- [x] At least one reviewer has tested and approved the code  

---

## Breaking changes
- [x] No breaking changes  
- [ ] Params/outputs/configs changed (list details in **Summary**)  
- [x] Output filenames or structure changed (document migration path)  

---

## Testing performed
Describe what was tested, datasets/profiles used, and results. Attach logs or links if helpful.

Performed by:  
- [ ] Viktor  
- [x] Ram  
- [ ] Sailedra  

---

## Notes for reviewers
Please check the shell code syntax
---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [x] Sailedra  
