### PR TITLE
GMShem check samplesheet fail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.1.15
+- Fixed issue created with GMShem keeps failing at check samplesheet.
+
 ## 3.1.14
 - Fixed Gens command where `!` is printed in the filename and ids in the command.
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 
-# Released under the MIT license.
-# See git repository (https://github.com/nf-core/raredisease) for full license text.
-
-
 # if no header -> stop the pipeline
 # if no assay -> stop the pipeline
 # 
@@ -16,20 +12,30 @@
 
 import csv
 import argparse
+import json
+from pathlib import Path
 
-CMDAssay = [    
-                "gmslymphomav3-0", 
-                "GMSMyeloidv1-0", 
-                "gmssolidtumorv3-0", 
-                "PARPinhibv1-0" 
-            ]
+
+def load_allowed_assays(json_path):
+    with Path(json_path).open() as handle:
+        dataset = json.load(handle)
+
+    if isinstance(dataset, dict):
+        assays = dataset.get("cmd_assays", [])
+    elif isinstance(dataset, list):
+        assays = dataset
+    else:
+        raise ValueError("CMD assay JSON must be a list or contain a 'cmd_assays' list")
+
+    return {assay.strip() for assay in assays if assay and assay.strip()}
+
 def process_linescsv_file(test):
     with open(test, mode='r') as file:
         csvFile = csv.DictReader(file)
         nrows = len(list(csvFile))
         return (nrows)
     
-def process_csv_file(test,nrows):
+def process_csv_file(test, nrows, allowed_assays):
     testAssay = []
     testId = []
     testType = []
@@ -41,10 +47,11 @@ def process_csv_file(test,nrows):
             return None
         else:
             for row in csvFile:
-                if len(row["assay"]) == 0 and row["assay"][0] not in CMDAssay:
+                assay = row["assay"].strip()
+                if len(assay) == 0 or assay not in allowed_assays:
                     return None
                 else:
-                    testAssay.append(row["assay"])
+                    testAssay.append(assay)
 
                 if len(row["id"]) == 0:
                     return None
@@ -71,20 +78,23 @@ def Main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--csv', dest = 'csv',  default = "test.csv", help = "Sample Sheet csv for the nextflow")
     parser.add_argument('-o', '--out', dest = 'output', default = "result", help = "Input csv structure and content signal")
+    parser.add_argument(
+        '--cmd-assays-json',
+        dest='cmd_assays_json',
+        help='Path to a JSON file containing allowed CMD assay names.',
+    )
 
     args = parser.parse_args()
     inputCsv = args.csv
     outputCsv = args.output
+    allowed_assays = load_allowed_assays(args.cmd_assays_json)
     count = process_linescsv_file(inputCsv)
     
-    result = process_csv_file(inputCsv,count)
+    result = process_csv_file(inputCsv, count, allowed_assays)
 
     writeFile(result, outputCsv)
 
 if __name__ == "__main__":
     Main()
-
-
-
 
 

--- a/modules/local/check_input/main.nf
+++ b/modules/local/check_input/main.nf
@@ -13,7 +13,7 @@ process CSV_CHECK {
     script:
         def prefix = task.ext.prefix ?: "${samplesheet.baseName}"
         """
-        check_samplesheet.py -c ${samplesheet} -o samplecheck.txt
+        check_samplesheet.py -c ${samplesheet} -o samplecheck.txt --cmd-assays-json ${projectDir}/resources/cmd_assays.json
 
         if [[ -e "samplecheck.txt" ]]; then
             cp ${samplesheet} "${prefix}.checked.csv"

--- a/resources/cmd_assays.json
+++ b/resources/cmd_assays.json
@@ -19,6 +19,7 @@
    "mtuberculosis", 
    "kpneumoniae"  , 
    "unknown", 
-   "twistrnafusionv1-0"
+   "twistrnafusionv1-0",
+   "dev"
   ]
 }

--- a/resources/cmd_assays.json
+++ b/resources/cmd_assays.json
@@ -1,0 +1,24 @@
+{
+  "cmd_assays": [
+   "wgs-hg38", 
+   "oncov2-0", 
+   "mody-cftr-aatv1-0", 
+   "myeloid-const", 
+   "GMSMyeloidv1-0", 
+   "PARPinhibv2-0",
+   "GMSHemv1-1", 
+   "gmssolidtumorv3-0", 
+   "gmssolidtumorrnav5-0", 
+   "rnaseq-fusion", 
+   "rnaseq-exp-breast", 
+   "tumwgs-solid", 
+   "tumwgs-hema", 
+   "gmssolidpgx", 
+   "saureus", 
+   "ecoli", 
+   "mtuberculosis", 
+   "kpneumoniae"  , 
+   "unknown", 
+   "twistrnafusionv1-0"
+  ]
+}


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary
The issue seems really confusing as this should not happened. However having inspecting the codebase, seperated the SMD assays into the resources folder of the pipeline so that it can updated rather than hardcoded in the python script. Subsequently updated the check_input modules and create_meta subworkflow. This in turn should fix the samplesheet fail caused in #129. 
The whole pipeline was run through pipeEval workflow which can ran sucessfully in stub run and test datasets producing similar results to the main branch. The test results and pipeline folders can be accessed upon request.

---

## Type of change
- [X] Bug fix  

---

## Checklist (author)  

- [X] **CHANGELOG** updated with a clear entry   
- [X] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [X] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [X] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [X] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)   

---

## Breaking changes
- [X] No breaking changes  

---

## Testing performed
Describe what was tested, datasets/profiles used, and results. Attach logs or links if helpful.

Performed by:  
- [ ] Viktor  
- [ ] Ram  
- [X] Sailendra  

(Add if missing)

---

## Notes for reviewers
PipeEval can be run. 
---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [ ] Sailedra  

