### PR TITLE
fix(cnvkit): skip nexus-ogt export for empty VCFs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.1.17
+- Fixed CNVkit call step to skip optional Nexus OGT BAF/LogR export when the input VCF has no variant records.
+
 ## 3.1.15
 - Fixed issue created with GMShem keeps failing at check samplesheet.
 

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -733,7 +733,7 @@ manifest {
     description     = 'call and annoate variants from WGS/WES of cancer patients'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version         = '3.1.14'
+    version         = '3.1.17'
 }
 
 // Include necessary configs

--- a/modules/local/cnvkit/main.nf
+++ b/modules/local/cnvkit/main.nf
@@ -194,7 +194,7 @@ process CNVKIT_CALL {
 
     output:
         tuple val(group), val(meta), val(part), file("*.${part}.call*.cns"),            emit: cnvkitsegment
-        tuple val(group), val(meta), val(part), file("*.${part}_logr_ballele.cnvkit"),  emit: cnvkit_baflogr
+        tuple val(group), val(meta), val(part), file("*.${part}_logr_ballele.cnvkit"),  emit: cnvkit_baflogr, optional: true
         tuple val(group), val(meta), val(part), file("*.${part}.cnvkit.vcf"),           emit: cnvkit_vcf
         path "versions.yml",                                                            emit: versions
 
@@ -214,9 +214,20 @@ process CNVKIT_CALL {
         }
 
         """
+        export MPLCONFIGDIR="\$PWD/.matplotlib"
+        mkdir -p "\$MPLCONFIGDIR"
+        
         $call
         $callvcf
-        cnvkit.py export nexus-ogt -o ${prefix}.${part}_logr_ballele.cnvkit ${cnr} ${vcf}
+
+        if zcat -f ${vcf} | grep -qv '^#'; then
+            cnvkit.py export nexus-ogt \
+                -o ${prefix}.${part}_logr_ballele.cnvkit \
+                ${cnr} \
+                ${vcf}
+        else
+            echo "Skipping CNVkit nexus-ogt export: empty VCF"
+        fi
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary
Fixes failure in `CNVKIT_CALL `process when running `cnvkit.py export nexus-ogt` with VCFs that contain no usable variant records.

Previously, the pipeline would crash due to a CNVkit internal error when the germline VCF was empty or lacked heterozygous SNPs required for BAF calculation. This caused the entire process to fail even though primary CNV outputs (`.call.cns`, `.cnvkit.vcf`) were generated successfully.

**Changes:**

1. Made `cnvkit_baflogr `output optional
2. Added a guard to skip the `nexus-ogt` export when VCF contains no variant records
3. Added fallback-safe execution to prevent pipeline failure
4. Set `MPLCONFIGDIR `to avoid matplotlib permission warnings

---

## Type of change
- [x] Bug fix  
- [x] Patch / hotfix  
- [ ] New feature / enhancement  
- [ ] Refactor / cleanup  
- [ ] Documentation update  


---

## Checklist (author)  

- [x] **CHANGELOG** updated with a clear entry   
- [x] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [x] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [x] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [x] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)  
- [ ] New data formats tested for compatibility with **Coyote3**  
- [ ] New data formats tested for compatibility with **GENS**  
- [ ] Documentation updated (README, params, examples, usage)  
- [ ] Containers / tools updated are version-pinned and reproducible  
- [ ] At least one reviewer has tested and approved the code  

---

## Breaking changes
- [x] No breaking changes  
- [ ] Params/outputs/configs changed (list details in **Summary**)  
- [ ] Output filenames or structure changed (document migration path)  

---

## Testing performed
Tested on:
- Real sample with empty / filtered germline VCF
- Stub runs

Performed by:  
- [ ] Viktor  
- [x] Ram  
- [ ] Sailedra  

(Add if missing)

---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [x] Sailedra  

(Add if missing)


