### PR TITLE
Fix/missing versions emit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 ## Changelog ##
 
+## 3.2.1
+- fixed the missing versions output emitted from the CONTAMINATION process in vcf_qc
 
 ## 3.2.0
 - Added sex check as vcf qc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# SomaticPanelPipeline
+<!-- test Julia -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # SomaticPanelPipeline
-<!-- test Julia -->
+

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -38,7 +38,7 @@ params {
   container_dir                       = '/fs1/resources/containers'
   container                           = "${params.container_dir}/SomaticPanelPipeline_2021-06-24.sif"
   // results dir //
-  resultsdir                          = "/fs1/results"
+  resultsdir                          = "/fs1/julia/results"
   dev                                 = false
   validation                          = false
   testing                             = false

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -38,7 +38,7 @@ params {
   container_dir                       = '/fs1/resources/containers'
   container                           = "${params.container_dir}/SomaticPanelPipeline_2021-06-24.sif"
   // results dir //
-  resultsdir                          = "/fs1/julia/results"
+  resultsdir                          = "/fs1/results"
   dev                                 = false
   validation                          = false
   testing                             = false

--- a/subworkflows/local/vcf_qc.nf
+++ b/subworkflows/local/vcf_qc.nf
@@ -37,5 +37,6 @@ workflow VCF_QC {
     emit:
         qcdone                  =   CONTAMINATION.out.contamination_cdm                  // channel: [ tuple val(group), file("dist.txt"), file("sampleid.png") ]
         results                 =   CONTAMINATION.out.contamination_result_files         // channel: [ val(group), val(meta), file(cdm) ]
+        versions                =   ch_versions
 
 }

--- a/workflows/common.nf
+++ b/workflows/common.nf
@@ -105,6 +105,8 @@ workflow SPP_COMMON {
         ch_vcf.normal_germline,
         CHECK_INPUT.out.meta
     )
+    .set { ch_qc_vcf }
+    ch_versions = ch_versions.mix(ch_qc_vcf.versions)
 
     CNV_CALLING ( 
         ch_mapped.bam_umi, 


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary
The "versions" for the CONTAMINATION process in vcf_qc.nf was not part of the emit section and now has been added. Similarly, the collection of this versions output is now included in the workflow common.nf. The output affected is called "yml" [ path "*.software_versions.yml"    , emit: yml ]  from the process CUSTOM_DUMPSOFTWAREVERSIONS which now includes the version (of perl) for the  CONTAMINATION part.

---
## Type of change
- [ ] Bug fix  
- [ ] Patch / hotfix  
- [x] New feature / enhancement  (=> tools/software versions collection)
- [ ] Refactor / cleanup  
- [ ] Documentation update  
---

## Checklist (author)  
- [ ] **CHANGELOG** updated with a clear entry   
- [ ] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [x] Pipeline -entry SPP run successfully using -resume (`-profile hg38,GMSHem`) using a test sample  
- [ ] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)
- [x] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`) 
- [ ] New data formats tested for compatibility with **Coyote3**  
- [ ] New data formats tested for compatibility with **GENS**  
- [ ] Documentation updated (README, params, examples, usage)  
- [ ] Containers / tools updated are version-pinned and reproducible  
- [ ] At least one reviewer has tested and approved the code 

---

## Breaking changes
- [x] No breaking changes
- [ ] Params/outputs/configs changed (list details in **Summary**)  
- [ ] Output filenames or structure changed (document migration path)   

---

## Testing performed
test sample used:
/fs2/seqdata/restored/SomaticPanelPipeline_test_samples/CMD1265A2_122-614308_S37_R1_001.fastq.gz and 
/fs2/seqdata/restored/SomaticPanelPipeline_test_samples/CMD1265A2_122-614308_S37_R2_001.fastq.gz 
located at /fs1/julia/pipelines/test_samples/Somatic_test_file.csv

Pipeline run here:
(Hopper) /fs1/julia/pipelines/SomaticPanelPipeline/clone

using the command line:
nextflow run main.nf -entry SPP -profile hg38,GMSHem --csv ../../test_samples/Somatic_test_file.csv -resume

trace report: " (Hopper) /fs1/julia/pipelines/SomaticPanelPipeline/clone/trace-20260521-58984453.txt"
report html: (Hopper) /fs1/julia/pipelines/SomaticPanelPipeline/clone/report-20260521-58984453.html

work dir for results of the pipeline run are here: (Hopper) /fs1/julia/pipelines/SomaticPanelPipeline/clone/work
for the PROCESS output affected:
work dir (Hopper) before modif is: [67/504e15]	5555428	SPP:SPP_COMMON:CUSTOM_DUMPSOFTWAREVERSIONS
work dir (Hopper) after modif is: [b4/287603]
resultdir: (Hopper) /fs1/julia/results/gmshem/pipeline_info/HD829-61265-260116-test.software_versions.yml

Performed by: 
- [ ] Viktor  
- [ ] Ram  
- [ ] Sailedra 
- [X] Julia
---

## Notes for reviewers
Mention risk areas, edge cases, or anything needing special attention. 

---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [ ] Sailedra  

(Add if missing)

---

## Release notes (draft)
Short, user-facing bullet points for the next release tag.
