### PR TITLE
Fix/coyote outputs issue121

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.2.2
+- process COYOTE_YAML in add_to_db.nf replaced by processes OUTPUT_FILES and OUTPUTS_YAML_COYOTE to create a YAML for Coyote3 without echoing info and without the use of FindIndexOf for optional files.
+
 ## 3.2.1
 - fixed the missing versions output emitted from the CONTAMINATION process in vcf_qc
 

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -80,7 +80,7 @@ def main():
         'genome_build':            38,
         'vcf_files':               build_access_path(args.subdir, 'vcf', args.vcf),
         'sample_no':               len(all_samples_meta),
-        'case_id':                 tumor_samplea['id'],
+        'case_id':                 tumor_sample['id'],
         'control_id':              normal_sample['id']                 if is_paired else None,
         'profile':                 args.environment,
         'assay':                   args.assay,

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -8,7 +8,7 @@ def parse_args():
         description='Generate a COYOTE YAML document from SomaticPanelPipeline outputs and all_samples_metadata'
     )
     parser.add_argument('--group',            required=True, help='sample group name')
-    parser.add_argument('--all_samples_meta',             required=True, help='path to all_samples_meta JSON file - one dict per sample')
+    parser.add_argument('--meta',             required=True, help='path to meta JSON file - one dict per sample')
     parser.add_argument('--vcf',              required=True, help='VCF filename')
     parser.add_argument('--json_info',        required=True, help='path to JSON file containing output filenames')
     parser.add_argument('--subdir',           required=True, help='pipeline subdirectory for building /access/ paths')
@@ -49,7 +49,7 @@ def main():
     # e.g. single: [{"id": "HD829", "type": "T", ...}]
     # e.g. paired: [{"id": "HD829", "type": "T", ...}, {"id": "26MD", "type": "N", ...}]
 
-    with open(args.all_samples_meta) as meta_file:
+    with open(args.meta) as meta_file:
         all_samples_meta = json.load(meta_file)
 
     # output_files maps Coyote YAML keys to their staged filenames

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -2,57 +2,86 @@
 
 import argparse
 import json
-import yaml
 
 def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--group',            required=True)
-    parser.add_argument('--meta',             required=True, help='path to meta JSON file')
-    parser.add_argument('--vcf',              required=True)
-    parser.add_argument('--json_info',        required=True)
-    parser.add_argument('--subdir',           required=True)
-    parser.add_argument('--assay',            required=True)
-    parser.add_argument('--environment',      required=True)
-    parser.add_argument('--pipeline_name',    required=True)
-    parser.add_argument('--pipeline_version', required=True)
-    parser.add_argument('--out',              required=True)
+    parser = argparse.ArgumentParser(
+        description='Generate a COYOTE YAML document from SomaticPanelPipeline outputs and all_samples_metadata'
+    )
+    parser.add_argument('--group',            required=True, help='sample group name')
+    parser.add_argument('--all_samples_meta',             required=True, help='path to all_samples_meta JSON file - one dict per sample')
+    parser.add_argument('--vcf',              required=True, help='VCF filename')
+    parser.add_argument('--json_info',        required=True, help='path to JSON file containing output filenames')
+    parser.add_argument('--subdir',           required=True, help='pipeline subdirectory for building /access/ paths')
+    parser.add_argument('--assay',            required=True, help='coyote group/assay name')
+    parser.add_argument('--environment',      required=True, help='production, development, validation, or testing')
+    parser.add_argument('--pipeline_name',    required=True, help='pipeline name from workflow manifest')
+    parser.add_argument('--pipeline_version', required=True, help='pipeline version from workflow manifest')
+    parser.add_argument('--out',              required=True, help='output YAML filename')
     return parser.parse_args()
 
 def build_access_path(subdir, subfolder, filename):
+    """Build the /access/ path used by Coyote to locate a file."""
     return f"/access/{subdir}/{subfolder}/{filename}"
+
+def write_yaml(coyote_doc, out_filepath):
+    """
+    Write a flat YAML file.
+    Handles None, bool, int/float and string values with correct YAML formatting.
+    """
+    with open(out_filepath, 'w') as yaml_file:
+        yaml_file.write('---\n')  # Start of YAML document
+        for yaml_key, yaml_value in coyote_doc.items():
+            if yaml_value is None:
+                 # YAML null for absent values
+                yaml_file.write(f"{yaml_key}: null\n")
+            elif isinstance(yaml_value, bool):
+                # YAML booleans must be lowercase true/false
+                yaml_file.write(f"{yaml_key}: {'true' if yaml_value else 'false'}\n")
+            elif isinstance(yaml_value, (int, float)):
+                # numbers are written without quotes
+                yaml_file.write(f"{yaml_key}: {yaml_value}\n")
+            else:  # strings are single-quoted
+                yaml_file.write(f"{yaml_key}: '{yaml_value}'\n")
 
 def main():
     args = parse_args()
+    # meta is a list of per-sample dicts — one dict per CSV row
+    # e.g. single: [{"id": "HD829", "type": "T", ...}]
+    # e.g. paired: [{"id": "HD829", "type": "T", ...}, {"id": "26MD", "type": "N", ...}]
 
-    with open(args.meta) as meta_file:
-        meta = json.load(meta_file)
+    with open(args.all_samples_meta) as meta_file:
+        all_samples_meta = json.load(meta_file)
 
+    # output_files maps Coyote YAML keys to their staged filenames
+    # e.g. {"cnv": "HD829.cnvs.merged.json", "cov": "HD829.cov.json", ...}
     with open(args.json_info) as info_file:
         output_files = json.load(info_file)
 
-    # determine tumor and normal sample indices
-    sample_types = meta['type'] if isinstance(meta['type'], list) else [meta['type']]
-    tumor_idx    = next(i for i, t in enumerate(sample_types) if t in ('T', 'tumor'))
-    normal_idx   = next((i for i, t in enumerate(sample_types) if t in ('N', 'normal')), None)
+    # identify tumor and normal sample from the list in all_samples_meta
+    tumor_sample    = next(s for s in all_samples_meta if s['type'] in ('T', 'tumor'))
+    normal_sample   = next((s for s in all_samples_meta if s['type'] in ('N', 'normal')), None)
 
-    is_paired      = normal_idx is not None
-    coyote_name    = args.group + 'p' if is_paired else args.group
-    tumor_purity   = float(meta['purity'][tumor_idx]) if meta['purity'][tumor_idx] else None
-    normal_purity  = float(meta['purity'][normal_idx]) if is_paired and meta['purity'][normal_idx] else None
+    is_paired      = normal_sample is not None
+
+    # for paired samples coyote expects the group name suffixed with 'p'
+    coyote_group_name = args.group + 'p' if is_paired else args.group
+
+    tumor_purity   = float(tumor_sample['purity']) if tumor_sample['purity'] else
+    normal_purity  = float(normal_sample['purity']) if ispaired and normal_sample['purity'] else None
 
     # fixed fields — always present regardless of profile
     coyote_doc = {
-        'subpanel':                meta['diagnosis'][tumor_idx],
-        'name':                    coyote_name,
-        'clarity_case_id':         meta['clarity_sample_id'][tumor_idx],
-        'clarity_control_id':      meta['clarity_sample_id'][normal_idx]  if is_paired else None,
-        'clarity_case_pool_id':    meta['clarity_pool_id'][tumor_idx],
-        'clarity_control_pool_id': meta['clarity_pool_id'][normal_idx]    if is_paired else None,
+        'subpanel':                tumor_sample['diagnosis'],
+        'name':                    coyote_group_name,
+        'clarity_case_id':         tumor_sample['clarity_sample_id'],
+        'clarity_control_id':      normal_sample['clarity_sample_id']  if is_paired else None,
+        'clarity_case_pool_id':    tumor_sample['clarity_pool_id'],
+        'clarity_control_pool_id': normal_sample['clarity_pool_id']    if is_paired else None,
         'genome_build':            38,
         'vcf_files':               build_access_path(args.subdir, 'vcf', args.vcf),
-        'sample_no':               len(meta['id']),
-        'case_id':                 meta['id'][tumor_idx],
-        'control_id':              meta['id'][normal_idx]                  if is_paired else None,
+        'sample_no':               len(all_samples_meta),
+        'case_id':                 tumor_samplea['id'],
+        'control_id':              normal_sample['id']                 if is_paired else None,
         'profile':                 args.environment,
         'assay':                   args.assay,
         'sequencing_scope':        'panel',
@@ -60,25 +89,26 @@ def main():
         'sequencing_technology':   'Illumina',
         'pipeline':                args.pipeline_name,
         'pipeline_version':        args.pipeline_version,
-        'case_ffpe':               meta['ffpe'][tumor_idx],
-        'case_sequencing_run':     meta['sequencing_run'][tumor_idx],
-        'case_reads':              meta['reads'][tumor_idx],
+        'case_ffpe':               tumor_sample['ffpe'],
+        'case_sequencing_run':     tumor_sample['sequencing_run'],
+        'case_reads':              tumor_sample['reads'],
         'case_purity':             tumor_purity,
-        'control_ffpe':            meta['ffpe'][normal_idx]                if is_paired else None,
-        'control_sequencing_run':  meta['sequencing_run'][normal_idx]      if is_paired else None,
-        'control_reads':           meta['reads'][normal_idx]               if is_paired else None,
+        'control_ffpe':            normal_sample['ffpe']                if is_paired else None,
+        'control_sequencing_run':  normal_sample['sequencing_run']      if is_paired else None,
+        'control_reads':           normal_sample['reads']               if is_paired else None,
         'control_purity':          normal_purity,
         'paired':                  is_paired,
     }
 
     # cnvprofile: gatk (modeled.png) preferred over cnvkit (cnvkit_overview.png)
+    # only one cnvprofile field appears in the final YAML
     if 'cnvprofile_gatk' in output_files:
         coyote_doc['cnvprofile'] = build_access_path(args.subdir, 'plots', output_files['cnvprofile_gatk'])
     elif 'cnvprofile_cnvkit' in output_files:
         coyote_doc['cnvprofile'] = build_access_path(args.subdir, 'plots', output_files['cnvprofile_cnvkit'])
 
-    # optional file fields — only added if present in output_files
-    optional_subfolders = {
+    # optional file fields — only added if present in output_files (json_INFO from OUTPUT_FILES process)
+    optional_file_subfolders = {
         'cnv':        'cnv',
         'transloc':   'fusions',
         'biomarkers': 'biomarkers',
@@ -86,20 +116,16 @@ def main():
         'lowcov':     'QC',
     }
 
-    for coyote_key, subfolder in optional_subfolders.items():
+    for coyote_key, subfolder in optional_file_subfolders.items():
         if coyote_key in output_files:
             coyote_doc[coyote_key] = build_access_path(args.subdir, subfolder, output_files[coyote_key])
 
-    # purity as standalone field — mirrors existing behaviour in COYOTE_YAML process
+    # purity is also written as a standalone field at the end
+    # this mirrors the existing line in the COYOTE_YAML process
     if tumor_purity is not None:
         coyote_doc['purity'] = tumor_purity
 
-    with open(args.out, 'w') as output_yaml:
-        yaml.dump(coyote_doc, output_yaml,
-                  default_flow_style=False,
-                  allow_unicode=True,
-                  sort_keys=False,
-                  explicit_start=True)
+    write_yaml(coyote_doc, args.out)
 
 if __name__ == '__main__':
     main()

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -35,12 +35,15 @@ def write_yaml(coyote_doc, out_filepath):
                  # YAML null for absent values
                 yaml_file.write(f"{yaml_key}: null\n")
             elif isinstance(yaml_value, bool):
+                # Checks if the value is a Python boolean
                 # YAML booleans must be lowercase true/false
                 yaml_file.write(f"{yaml_key}: {'true' if yaml_value else 'false'}\n")
             elif isinstance(yaml_value, (int, float)):
                 # numbers are written without quotes
+            elif isinstance(yaml_value, str) and yaml_value.startswith('/access/'):
+                # paths are written without quotes.
                 yaml_file.write(f"{yaml_key}: {yaml_value}\n")
-            else:  # strings are single-quoted
+            else:  # all other cases treated as strings qhich are single-quoted
                 yaml_file.write(f"{yaml_key}: '{yaml_value}'\n")
 
 def main():
@@ -65,6 +68,10 @@ def main():
 
     # for paired samples coyote expects the group name suffixed with 'p'
     coyote_group_name = args.group + 'p' if is_paired else args.group
+
+    # reads and purity are converted to int and float types, respectively, for YAML output
+    tumor_reads  = int(tumor_sample['reads'])  if tumor_sample['reads']  else None
+    normal_reads = int(normal_sample['reads']) if is_paired and normal_sample['reads'] else None
 
     tumor_purity   = float(tumor_sample['purity']) if tumor_sample['purity'] else None
     normal_purity  = float(normal_sample['purity']) if is_paired and normal_sample['purity'] else None

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""
+Description: this script generates a YAML document for Coyote3 data import, combining meta info, optional file locations and other
+parameters. This script was created to replace the currently used processes "COYOTE" and "COYOTE_YAML".
+"""
 
 import argparse
 import json

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -99,11 +99,11 @@ def main():
         'pipeline_version':        args.pipeline_version,
         'case_ffpe':               tumor_sample['ffpe'],
         'case_sequencing_run':     tumor_sample['sequencing_run'],
-        'case_reads':              tumor_sample['reads'],
+        'case_reads':              tumor_reads,
         'case_purity':             tumor_purity,
         'control_ffpe':            normal_sample['ffpe']                if is_paired else None,
         'control_sequencing_run':  normal_sample['sequencing_run']      if is_paired else None,
-        'control_reads':           normal_sample['reads']               if is_paired else None,
+        'control_reads':           normal_reads                         if is_paired else None,
         'control_purity':          normal_purity,
         'paired':                  is_paired,
     }

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -42,9 +42,9 @@ def write_yaml(coyote_doc, out_filepath):
                 # numbers are written without quotes
                 yaml_file.write(f"{yaml_key}: {yaml_value}\n")
             elif isinstance(yaml_value, str) and yaml_value.startswith('/access/'):
-                # paths are written without quotes.
+                # to fit the old yaml way where paths are written without quotes.
                 yaml_file.write(f"{yaml_key}: {yaml_value}\n")
-            else:  # all other cases treated as strings qhich are single-quoted
+            else:  # all other cases treated as strings which are single-quoted
                 yaml_file.write(f"{yaml_key}: '{yaml_value}'\n")
 
 def main():

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import yaml
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--group',            required=True)
+    parser.add_argument('--meta',             required=True, help='path to meta JSON file')
+    parser.add_argument('--vcf',              required=True)
+    parser.add_argument('--json_info',        required=True)
+    parser.add_argument('--subdir',           required=True)
+    parser.add_argument('--assay',            required=True)
+    parser.add_argument('--environment',      required=True)
+    parser.add_argument('--pipeline_name',    required=True)
+    parser.add_argument('--pipeline_version', required=True)
+    parser.add_argument('--out',              required=True)
+    return parser.parse_args()
+
+def build_access_path(subdir, subfolder, filename):
+    return f"/access/{subdir}/{subfolder}/{filename}"
+
+def main():
+    args = parse_args()
+
+    with open(args.meta) as meta_file:
+        meta = json.load(meta_file)
+
+    with open(args.json_info) as info_file:
+        output_files = json.load(info_file)
+
+    # determine tumor and normal sample indices
+    sample_types = meta['type'] if isinstance(meta['type'], list) else [meta['type']]
+    tumor_idx    = next(i for i, t in enumerate(sample_types) if t in ('T', 'tumor'))
+    normal_idx   = next((i for i, t in enumerate(sample_types) if t in ('N', 'normal')), None)
+
+    is_paired      = normal_idx is not None
+    coyote_name    = args.group + 'p' if is_paired else args.group
+    tumor_purity   = float(meta['purity'][tumor_idx]) if meta['purity'][tumor_idx] else None
+    normal_purity  = float(meta['purity'][normal_idx]) if is_paired and meta['purity'][normal_idx] else None
+
+    # fixed fields — always present regardless of profile
+    coyote_doc = {
+        'subpanel':                meta['diagnosis'][tumor_idx],
+        'name':                    coyote_name,
+        'clarity_case_id':         meta['clarity_sample_id'][tumor_idx],
+        'clarity_control_id':      meta['clarity_sample_id'][normal_idx]  if is_paired else None,
+        'clarity_case_pool_id':    meta['clarity_pool_id'][tumor_idx],
+        'clarity_control_pool_id': meta['clarity_pool_id'][normal_idx]    if is_paired else None,
+        'genome_build':            38,
+        'vcf_files':               build_access_path(args.subdir, 'vcf', args.vcf),
+        'sample_no':               len(meta['id']),
+        'case_id':                 meta['id'][tumor_idx],
+        'control_id':              meta['id'][normal_idx]                  if is_paired else None,
+        'profile':                 args.environment,
+        'assay':                   args.assay,
+        'sequencing_scope':        'panel',
+        'omics_layer':             'DNA',
+        'sequencing_technology':   'Illumina',
+        'pipeline':                args.pipeline_name,
+        'pipeline_version':        args.pipeline_version,
+        'case_ffpe':               meta['ffpe'][tumor_idx],
+        'case_sequencing_run':     meta['sequencing_run'][tumor_idx],
+        'case_reads':              meta['reads'][tumor_idx],
+        'case_purity':             tumor_purity,
+        'control_ffpe':            meta['ffpe'][normal_idx]                if is_paired else None,
+        'control_sequencing_run':  meta['sequencing_run'][normal_idx]      if is_paired else None,
+        'control_reads':           meta['reads'][normal_idx]               if is_paired else None,
+        'control_purity':          normal_purity,
+        'paired':                  is_paired,
+    }
+
+    # cnvprofile: gatk (modeled.png) preferred over cnvkit (cnvkit_overview.png)
+    if 'cnvprofile_gatk' in output_files:
+        coyote_doc['cnvprofile'] = build_access_path(args.subdir, 'plots', output_files['cnvprofile_gatk'])
+    elif 'cnvprofile_cnvkit' in output_files:
+        coyote_doc['cnvprofile'] = build_access_path(args.subdir, 'plots', output_files['cnvprofile_cnvkit'])
+
+    # optional file fields — only added if present in output_files
+    optional_subfolders = {
+        'cnv':        'cnv',
+        'transloc':   'fusions',
+        'biomarkers': 'biomarkers',
+        'cov':        'QC',
+        'lowcov':     'QC',
+    }
+
+    for coyote_key, subfolder in optional_subfolders.items():
+        if coyote_key in output_files:
+            coyote_doc[coyote_key] = build_access_path(args.subdir, subfolder, output_files[coyote_key])
+
+    # purity as standalone field — mirrors existing behaviour in COYOTE_YAML process
+    if tumor_purity is not None:
+        coyote_doc['purity'] = tumor_purity
+
+    with open(args.out, 'w') as output_yaml:
+        yaml.dump(coyote_doc, output_yaml,
+                  default_flow_style=False,
+                  allow_unicode=True,
+                  sort_keys=False,
+                  explicit_start=True)
+
+if __name__ == '__main__':
+    main()

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -67,7 +67,7 @@ def main():
     coyote_group_name = args.group + 'p' if is_paired else args.group
 
     tumor_purity   = float(tumor_sample['purity']) if tumor_sample['purity'] else None
-    normal_purity  = float(normal_sample['purity']) if ispaired and normal_sample['purity'] else None
+    normal_purity  = float(normal_sample['purity']) if is_paired and normal_sample['purity'] else None
 
     # fixed fields — always present regardless of profile
     coyote_doc = {

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -66,7 +66,7 @@ def main():
     # for paired samples coyote expects the group name suffixed with 'p'
     coyote_group_name = args.group + 'p' if is_paired else args.group
 
-    tumor_purity   = float(tumor_sample['purity']) if tumor_sample['purity'] else
+    tumor_purity   = float(tumor_sample['purity']) if tumor_sample['purity'] else None
     normal_purity  = float(normal_sample['purity']) if ispaired and normal_sample['purity'] else None
 
     # fixed fields — always present regardless of profile

--- a/bin/make_coyote_yaml.py
+++ b/bin/make_coyote_yaml.py
@@ -40,6 +40,7 @@ def write_yaml(coyote_doc, out_filepath):
                 yaml_file.write(f"{yaml_key}: {'true' if yaml_value else 'false'}\n")
             elif isinstance(yaml_value, (int, float)):
                 # numbers are written without quotes
+                yaml_file.write(f"{yaml_key}: {yaml_value}\n")
             elif isinstance(yaml_value, str) and yaml_value.startswith('/access/'):
                 # paths are written without quotes.
                 yaml_file.write(f"{yaml_key}: {yaml_value}\n")

--- a/configs/modules/add_to_db.config
+++ b/configs/modules/add_to_db.config
@@ -66,14 +66,14 @@ process {
                 path: "${params.outdir}/${params.subdir}/coyote",
                 mode: 'copy',
                 overwrite: true,
-                pattern: "*.json_INFO"
+                pattern: "*.json_INFO",
             ],
             // Conditionally publish here
             [
                 path: "${params.crondir}/coyote",
                 mode: 'copy',
                 overwrite: true,
-                pattern: "*.json_INFO"
+                pattern: "*.json_INFO",
                 enabled: !params.noupload && params.coyote_cli
             ]
         ]

--- a/configs/modules/add_to_db.config
+++ b/configs/modules/add_to_db.config
@@ -59,7 +59,7 @@ process {
         ]
     }
 
-withName: '.*ADD_TO_DB:OUTPUT_FILES
+    withName: '.*ADD_TO_DB:OUTPUT_FILES' {
         // Always publish here
         publishDir = [
             [
@@ -80,7 +80,7 @@ withName: '.*ADD_TO_DB:OUTPUT_FILES
     }
 
 
-    withName: '.*ADD_TO_DB:OUTPUTS_YAML_COYOTE
+    withName: '.*ADD_TO_DB:OUTPUTS_YAML_COYOTE'{
         // Always publish here
         publishDir = [
             [

--- a/configs/modules/add_to_db.config
+++ b/configs/modules/add_to_db.config
@@ -66,14 +66,14 @@ process {
                 path: "${params.outdir}/${params.subdir}/coyote",
                 mode: 'copy',
                 overwrite: true,
-                pattern: "*.json_INFO
+                pattern: "*.json_INFO"
             ],
             // Conditionally publish here
             [
                 path: "${params.crondir}/coyote",
                 mode: 'copy',
                 overwrite: true,
-                pattern: "*.json_INFO
+                pattern: "*.json_INFO"
                 enabled: !params.noupload && params.coyote_cli
             ]
         ]

--- a/configs/modules/add_to_db.config
+++ b/configs/modules/add_to_db.config
@@ -59,4 +59,45 @@ process {
         ]
     }
 
+withName: '.*ADD_TO_DB:OUTPUT_FILES
+        // Always publish here
+        publishDir = [
+            [
+                path: "${params.outdir}/${params.subdir}/coyote",
+                mode: 'copy',
+                overwrite: true,
+                pattern: "*.json_INFO
+            ],
+            // Conditionally publish here
+            [
+                path: "${params.crondir}/coyote",
+                mode: 'copy',
+                overwrite: true,
+                pattern: "*.json_INFO
+                enabled: !params.noupload && params.coyote_cli
+            ]
+        ]
+    }
+
+
+    withName: '.*ADD_TO_DB:OUTPUTS_YAML_COYOTE
+        // Always publish here
+        publishDir = [
+            [
+                path: "${params.outdir}/${params.subdir}/coyote",
+                mode: 'copy',
+                overwrite: true,
+                pattern: "*.yaml",
+            ],
+            // Conditionally publish here
+            [
+                path: "${params.crondir}/coyote",
+                mode: 'copy',
+                overwrite: true,
+                pattern: "*.yaml",
+                enabled: !params.noupload && params.coyote_cli
+            ]
+        ]
+    }
+
 }

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -736,7 +736,7 @@ manifest {
     description     = 'call and annoate variants from WGS/WES of cancer patients'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version         = '3.2.2'
+    version         = '3.2.3'
 
 }
 

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -736,7 +736,7 @@ manifest {
     description     = 'call and annoate variants from WGS/WES of cancer patients'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version         = '3.2.0'
+    version         = '3.2.2'
 
 }
 

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -431,7 +431,7 @@ process  OUTPUTS_YAML_COYOTE {
         tuple val(group), val(meta), path(vcf), path(json_INFO)
 
     output:
-        tuple val(group), path("${group}_coyote3_new.yaml"), emit: yaml_coyote_new
+        tuple val(group), path("${group}.coyote3.yaml"), emit: yaml_coyote3
 
     when:
         task.ext.when == null || task.ext.when
@@ -457,12 +457,12 @@ process  OUTPUTS_YAML_COYOTE {
             --environment      '${environment}' \\
             --pipeline_name    '${workflow.manifest.name}' \\
             --pipeline_version '${workflow.manifest.version}' \\
-            --out              ${group}_coyote3_new.yaml
+            --out              ${group}.coyote3.yaml
             
         """
 
     stub:
         """
-        touch ${group}_coyote3_new.yaml
+        touch ${group}.coyote3.yaml
         """
 }

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -395,8 +395,8 @@ process COYOTE_YAML {
 process OUTPUT_FILES {
     label "process_single"  
     tag "$group" 
-    // this process is to create the json file with names of the optional files to be loaded into coyote, which
-    // are associated with their yaml labels (cnv, fusions, biomarkers, cnvplot, cov).
+    // this process creates a json file with names of the optional files to be loaded into coyote3. Those optional files are
+    // associated with their yaml labels (cnv, fusions, biomarkers, cnvplot, cov).
     input:
         tuple val(group), val(labels), path(files, stageAs: "?/*") // if files have the same name, they are staged 
 
@@ -408,7 +408,7 @@ process OUTPUT_FILES {
 
     script:
         def json_map = [labels, files.collect {it.toString().replaceAll('.+/', '')}] // remove path, keep file name only.
-            .transpose() // pair each <label> with corresponding file names.
+            .transpose() // pair each <yaml_label> with corresponding file names.
             .collectEntries { label, fname -> [(label): fname]  } 
 
         def json_str = groovy.json.JsonOutput.toJson(json_map) // Converts the Groovy map into a valid JSON string      
@@ -425,7 +425,7 @@ process OUTPUT_FILES {
 process  OUTPUTS_YAML_COYOTE {
     label "process_single"
     tag "$group"
-    // this process creates the yaml file for loading into coyote.
+    // this process creates the yaml file for loading into coyote3.
 
     input:
         tuple val(group), val(meta), path(vcf), path(json_INFO)
@@ -439,9 +439,10 @@ process  OUTPUTS_YAML_COYOTE {
     script:
         environment = params.dev ? 'development' : params.validation ? 'validation' : params.testing ? 'testing' : 'production'
         def meta_json    = groovy.json.JsonOutput.toJson(meta) // groovy.json.JsonOutput built-in Groovy class.
-        // meta written as a json instead of passed as a shell argument below 
+        // meta written as a json instead of passed as a shell argument as done previously in old COYOYE_YAML process.
         // avoid shell issues if meta fields contain special characters and
         // for easier passing of metadata to python
+        // the single quotation marks below are included here to be consistent with the previous yaml format, but they are not strictly necessary
         """
         cat << 'META_EOF' > meta.json
         ${meta_json}

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -407,7 +407,7 @@ process OUTPUT_FILES {
         task.ext.when == null || task.ext.when
 
     script:
-        def json_map = [labels, files.collect {it.name}]
+        def json_map = [labels, files.collect {it.fileName.toString()}]
             .transpose()
             .collectEntries { label, fname -> [(label): fname]  } 
 
@@ -421,6 +421,7 @@ process OUTPUT_FILES {
     
     """
 }
+
 
 
 process  OUTPUTS_YAML_COYOTE {

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -439,9 +439,27 @@ process  OUTPUTS_YAML_COYOTE {
 
     script:
         environment = params.dev ? 'development' : params.validation ? 'validation' : params.testing ? 'testing' : 'production'
-
+        def meta_json    = groovy.json.JsonOutput.toJson(meta) // groovy.json.JsonOutput built-in Groovy class.
+        // meta written as temp json instead of passed as a shell argument below 
+        // avoid shell issues if meta fields contain special characters.
+        // converting meta to json for easier passing of metadata to python
         """
-        echo "not implemented yet" > ${group}_coyote3_new.yaml
+        cat << 'META_EOF' > meta.json
+        ${meta_json}
+        META_EOF
+
+        make_coyote_yaml.py \\
+            --group            '${group}' \\
+            --meta             meta.json \\
+            --vcf              ${vcf} \\
+            --json_info        ${json_INFO} \\
+            --subdir           '${params.subdir}' \\
+            --assay            '${params.coyote_group}' \\
+            --environment      '${environment}' \\
+            --pipeline_name    '${workflow.manifest.name}' \\
+            --pipeline_version '${workflow.manifest.version}' \\
+            --out              ${group}.coyote3_new.yaml
+            
         """
 
     stub:

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -463,6 +463,17 @@ process  OUTPUTS_YAML_COYOTE {
 
     stub:
         """
+        echo "STUB: make_coyote_yaml.py would run with:"
+        echo "  --group            ${group}"
+        echo "  --meta             meta.json"
+        echo "  --vcf              ${vcf}"
+        echo "  --json_info        ${json_INFO}"
+        echo "  --subdir           ${params.subdir}"
+        echo "  --assay            ${params.coyote_group}"
+        echo "  --environment      ${environment}"
+        echo "  --pipeline_name    ${workflow.manifest.name}"
+        echo "  --pipeline_version ${workflow.manifest.version}"
+        echo "  --out              ${group}.coyote3.yaml"
         touch ${group}.coyote3.yaml
         """
 }

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -393,8 +393,8 @@ process COYOTE_YAML {
 }
 
 process OUTPUT_FILES {
-    label "process_single" // check 
-    tag "$group" // to check what I should put
+    label "process_single"  
+    tag "$group" 
     // this process is to create the json file with names of the optional files to be loaded into coyote, which
     // are associated with their yaml labels (cnv, fusions, biomarkers, cnvplot, cov).
     input:

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -392,11 +392,11 @@ process COYOTE_YAML {
         """
 }
 
-
 process OUTPUT_FILES {
     label "process_single" // check 
     tag "$group" // to check what I should put
-
+    // this process is to create the json file with names of the files to be loaded into coyote, and
+    // associated with their yaml labels (cnv, fusions, biomarkers, cnvplot, cov).
     input:
         tuple val(group), val(labels), path(files, stageAs: "?/*") // if files have the same name, they are staged 
 
@@ -422,11 +422,10 @@ process OUTPUT_FILES {
     """
 }
 
-
-
 process  OUTPUTS_YAML_COYOTE {
     label "process_single"
     tag "$group"
+    // this process creates the yaml file for loading into coyote.
 
     input:
         tuple val(group), val(meta), path(vcf), path(json_INFO)

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -462,6 +462,7 @@ process  OUTPUTS_YAML_COYOTE {
         """
 
     stub:
+        environment = params.dev ? 'development' : params.validation ? 'validation' : params.testing ? 'testing' : 'production'
         """
         echo "STUB: make_coyote_yaml.py would run with:"
         echo "  --group            ${group}"

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -423,8 +423,7 @@ process OUTPUT_FILES {
 }
 
 
-
-process  OUTPUTS_YAML_COYOYE {
+process  OUTPUTS_YAML_COYOTE {
     label "process_single"
     tag "$group"
 

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -407,7 +407,7 @@ process OUTPUT_FILES {
         task.ext.when == null || task.ext.when
 
     script:
-        def json_map = [labels, files.collect {it.fileName.toString()}]
+        def json_map = [labels, files.collect {it.toString().replaceAll('.+/', '')}]
             .transpose()
             .collectEntries { label, fname -> [(label): fname]  } 
 

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -458,7 +458,7 @@ process  OUTPUTS_YAML_COYOTE {
             --environment      '${environment}' \\
             --pipeline_name    '${workflow.manifest.name}' \\
             --pipeline_version '${workflow.manifest.version}' \\
-            --out              ${group}.coyote3_new.yaml
+            --out              ${group}_coyote3_new.yaml
             
         """
 

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -395,8 +395,8 @@ process COYOTE_YAML {
 process OUTPUT_FILES {
     label "process_single" // check 
     tag "$group" // to check what I should put
-    // this process is to create the json file with names of the files to be loaded into coyote, and
-    // associated with their yaml labels (cnv, fusions, biomarkers, cnvplot, cov).
+    // this process is to create the json file with names of the optional files to be loaded into coyote, which
+    // are associated with their yaml labels (cnv, fusions, biomarkers, cnvplot, cov).
     input:
         tuple val(group), val(labels), path(files, stageAs: "?/*") // if files have the same name, they are staged 
 
@@ -407,11 +407,11 @@ process OUTPUT_FILES {
         task.ext.when == null || task.ext.when
 
     script:
-        def json_map = [labels, files.collect {it.toString().replaceAll('.+/', '')}]
-            .transpose()
+        def json_map = [labels, files.collect {it.toString().replaceAll('.+/', '')}] // remove path, keep file name only.
+            .transpose() // pair each <label> with corresponding file names.
             .collectEntries { label, fname -> [(label): fname]  } 
 
-        def json_str = groovy.json.JsonOutput.toJson(json_map)       
+        def json_str = groovy.json.JsonOutput.toJson(json_map) // Converts the Groovy map into a valid JSON string      
         """
         echo '${json_str}' > ${group}_coyote.json_INFO
         """
@@ -439,9 +439,9 @@ process  OUTPUTS_YAML_COYOTE {
     script:
         environment = params.dev ? 'development' : params.validation ? 'validation' : params.testing ? 'testing' : 'production'
         def meta_json    = groovy.json.JsonOutput.toJson(meta) // groovy.json.JsonOutput built-in Groovy class.
-        // meta written as temp json instead of passed as a shell argument below 
-        // avoid shell issues if meta fields contain special characters.
-        // converting meta to json for easier passing of metadata to python
+        // meta written as a json instead of passed as a shell argument below 
+        // avoid shell issues if meta fields contain special characters and
+        // for easier passing of metadata to python
         """
         cat << 'META_EOF' > meta.json
         ${meta_json}

--- a/modules/local/coyote/main.nf
+++ b/modules/local/coyote/main.nf
@@ -391,3 +391,61 @@ process COYOTE_YAML {
         printf "$import_command" >> ${process_group}.coyote3.yaml
         """
 }
+
+
+process OUTPUT_FILES {
+    label "process_single" // check 
+    tag "$group" // to check what I should put
+
+    input:
+        tuple val(group), val(labels), path(files, stageAs: "?/*") // if files have the same name, they are staged 
+
+    output:
+        tuple val(group), path("${group}_coyote.json_INFO"), emit:json_INFO
+
+    when:
+        task.ext.when == null || task.ext.when
+
+    script:
+        def json_map = [labels, files.collect {it.name}]
+            .transpose()
+            .collectEntries { label, fname -> [(label): fname]  } 
+
+        def json_str = groovy.json.JsonOutput.toJson(json_map)       
+        """
+        echo '${json_str}' > ${group}_coyote.json_INFO
+        """
+    stub:
+    """
+    touch ${group}_coyote.json_INFO
+    
+    """
+}
+
+
+
+process  OUTPUTS_YAML_COYOYE {
+    label "process_single"
+    tag "$group"
+
+    input:
+        tuple val(group), val(meta), path(vcf), path(json_INFO)
+
+    output:
+        tuple val(group), path("${group}_coyote3_new.yaml"), emit: yaml_coyote_new
+
+    when:
+        task.ext.when == null || task.ext.when
+
+    script:
+        environment = params.dev ? 'development' : params.validation ? 'validation' : params.testing ? 'testing' : 'production'
+
+        """
+        echo "not implemented yet" > ${group}_coyote3_new.yaml
+        """
+
+    stub:
+        """
+        touch ${group}_coyote3_new.yaml
+        """
+}

--- a/subworkflows/local/add_to_db.nf
+++ b/subworkflows/local/add_to_db.nf
@@ -52,14 +52,14 @@ workflow ADD_TO_DB {
         optional = lc.mix(s_json,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
         optional_json = lc_d4.mix(s_json,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
         COYOTE { vcf.join(optional) }
-        COYOTE_YAML { vcf.join(optional_json) }
+        // COYOTE_YAML { vcf.join(optional_json) }
         ch_coyote_info_grouped = ch_coyote_info.groupTuple()
         OUTPUT_FILES ( ch_coyote_info_grouped )
         OUTPUTS_YAML_COYOTE ( vcf.join(OUTPUT_FILES.out.json_INFO) ) 
 
     emit:
         coyotedone = COYOTE.out.coyote_import        // channel: [ val(group), file(coyote) ]
-        coyotedone = COYOTE_YAML.out.coyote_import   // channel: [ val(group), file(coyote) ]
-        coyotedone = OUTPUTS_YAML_COYOTE.out.yaml_coyote_new // channel: [ val(group), file(coyote) ]
+        //coyotedone = COYOTE_YAML.out.coyote_import   // channel: [ val(group), file(coyote) ]
+        coyoteyaml = OUTPUTS_YAML_COYOTE.out.yaml_coyote3 // channel: [ val(group), file(coyote) ]
 }
 

--- a/subworkflows/local/add_to_db.nf
+++ b/subworkflows/local/add_to_db.nf
@@ -3,7 +3,7 @@
 include { COYOTE_YAML          } from '../../modules/local/coyote/main'
 include { COYOTE               } from '../../modules/local/coyote/main'
 include { OUTPUT_FILES         } from '../../modules/local/coyote/main'
-include { OUTPUTS_YAML_COYOYE } from '../../modules/local/coyote/main'
+include { OUTPUTS_YAML_COYOTE  } from '../../modules/local/coyote/main'
 
 workflow ADD_TO_DB {
 
@@ -56,12 +56,14 @@ workflow ADD_TO_DB {
         optional_json = lc_d4.mix(s_json,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
         COYOTE { vcf.join(optional) }
         COYOTE_YAML { vcf.join(optional_json) }
-        OUTPUT_FILES ( ch_coyote_info.groupTuple() )
-        OUTPUTS_YAML_COYOYE ( vcf.join(OUTPUT_FILES.out.json_INFO) ) 
+        ch_coyote_info_grouped = ch_coyote_info.groupTuple()
+        ch_coyote_info_grouped.view { "COYOTE INFO: $it" } // remove when no longer needed for debugging
+        OUTPUT_FILES ( ch_coyote_info_grouped )
+        OUTPUTS_YAML_COYOTE ( vcf.join(OUTPUT_FILES.out.json_INFO) ) 
 
     emit:
         coyotedone = COYOTE.out.coyote_import        // channel: [ val(group), file(coyote) ]
         coyotedone = COYOTE_YAML.out.coyote_import   // channel: [ val(group), file(coyote) ]
-        coyotedone = OUTPUTS_YAML_COYOYE.out.yaml_coyote // channel: [ val(group), file(coyote) ]
+        coyotedone = OUTPUTS_YAML_COYOTE.out.yaml_coyote_new // channel: [ val(group), file(coyote) ]
 }
 

--- a/subworkflows/local/add_to_db.nf
+++ b/subworkflows/local/add_to_db.nf
@@ -54,7 +54,6 @@ workflow ADD_TO_DB {
         COYOTE { vcf.join(optional) }
         COYOTE_YAML { vcf.join(optional_json) }
         ch_coyote_info_grouped = ch_coyote_info.groupTuple()
-        ch_coyote_info_grouped.view { "COYOTE INFO: $it" } // remove when no longer needed for debugging
         OUTPUT_FILES ( ch_coyote_info_grouped )
         OUTPUTS_YAML_COYOTE ( vcf.join(OUTPUT_FILES.out.json_INFO) ) 
 

--- a/subworkflows/local/add_to_db.nf
+++ b/subworkflows/local/add_to_db.nf
@@ -34,9 +34,6 @@ workflow ADD_TO_DB {
         }.set { cnvkit_png }
 
         ch_coyote_info = ch_coyote_info
-        .mix(lowcov
-            .filter { group, type, file -> type == 'T' || type == 'tumor' }
-            .map {group, type, file -> tuple(group, 'lowcov', file) }) // using directly the naming in coyote yaml for lowcov.bed
         .mix(lowcov_d4
             .filter { group, type, file -> type == 'T' || type == 'tumor' }
             .map {group, type, file -> tuple(group, 'cov', file) }) // using directly the naming in coyote yaml for coyote_cov_json

--- a/subworkflows/local/add_to_db.nf
+++ b/subworkflows/local/add_to_db.nf
@@ -2,8 +2,11 @@
 
 include { COYOTE_YAML          } from '../../modules/local/coyote/main'
 include { COYOTE               } from '../../modules/local/coyote/main'
+include { OUTPUT_FILES         } from '../../modules/local/coyote/main'
+include { OUTPUTS_YAML_COYOYE } from '../../modules/local/coyote/main'
 
 workflow ADD_TO_DB {
+
     take: 
         vcf             // channel: [mandatory] [ val(group), val(meta), file(vcf) ]
         lowcov          // channel: [mandatory] [ val(group), val(meta.type), file(lowcov) ]
@@ -17,6 +20,7 @@ workflow ADD_TO_DB {
         cnvkit_plot     // channel: [optional] [ val(group), val(meta), val(part), file(cnvkit_overview.png) ]
 
     main:
+        ch_coyote_info = Channel.empty() // Gather data for json_INFO listinf output files for export into Coyote
         lc = lowcov.map{ val-> tuple(val[0], val[2] ) }
         lc_d4 = lowcov_d4.map{ val-> tuple(val[0], val[2] ) }
         cnvkit_plot.groupTuple().set { cnvkit_plot_ch }
@@ -29,14 +33,35 @@ workflow ADD_TO_DB {
             }
         }.set { cnvkit_png }
 
+        ch_coyote_info = ch_coyote_info
+        .mix(lowcov
+            .filter { group, type, file -> type == 'T' || type == 'tumor' }
+            .map {group, type, file -> tuple(group, 'lowcov', file) }) // using directly the naming in coyote yaml for lowcov.bed
+        .mix(lowcov_d4
+            .filter { group, type, file -> type == 'T' || type == 'tumor' }
+            .map {group, type, file -> tuple(group, 'cov', file) }) // using directly the naming in coyote yaml for coyote_cov_json
+        .mix(gatcov_plot
+            .map { group, file -> tuple(group, 'cnvprofile_gatk', file) }) // file is modeled.png (preferred for coyote)
+        .mix(cnvkit_plot
+            .filter { group, meta, part, file -> meta.type == 'T' || meta.type == 'tumor'} 
+            .map { group, meta, part, file -> tuple(group, 'cnvprofile_cnvkit', file) }) // file is cnvkit_overview.png (if modeled.png absent)
+        .mix(s_json
+            .map { group, file -> tuple(group, 'cnv', file) }) // using directly the naming in coyote yaml)
+        .mix(fusions
+            .map { group, file -> tuple(group, 'transloc', file) }) // using directly the naming in coyote yaml for merged.annotated.vcf
+        .mix(biomarkers
+            .map { group, file -> tuple(group, 'biomarkers', file) }) // using directly the naming in coyote yaml for bio.json
+    
         optional = lc.mix(s_json,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
         optional_json = lc_d4.mix(s_json,gatcov_plot,biomarkers,fusions,cnvkit_png).groupTuple()
         COYOTE { vcf.join(optional) }
         COYOTE_YAML { vcf.join(optional_json) }
-        
+        OUTPUT_FILES ( ch_coyote_info.groupTuple() )
+        OUTPUTS_YAML_COYOYE ( vcf.join(OUTPUT_FILES.out.json_INFO) ) 
 
     emit:
         coyotedone = COYOTE.out.coyote_import        // channel: [ val(group), file(coyote) ]
-        coyotedone = COYOTE_YAML.out.coyote_import   // channel: [ val(group), file(coyote) ]     
+        coyotedone = COYOTE_YAML.out.coyote_import   // channel: [ val(group), file(coyote) ]
+        coyotedone = OUTPUTS_YAML_COYOYE.out.yaml_coyote // channel: [ val(group), file(coyote) ]
 }
 

--- a/subworkflows/local/add_to_db.nf
+++ b/subworkflows/local/add_to_db.nf
@@ -2,8 +2,8 @@
 
 include { COYOTE_YAML          } from '../../modules/local/coyote/main'
 include { COYOTE               } from '../../modules/local/coyote/main'
-include { OUTPUT_FILES         } from '../../modules/local/coyote/main'
-include { OUTPUTS_YAML_COYOTE  } from '../../modules/local/coyote/main'
+include { OUTPUT_FILES         } from '../../modules/local/coyote/main' // newly added process to ease data import into Coyote3
+include { OUTPUTS_YAML_COYOTE  } from '../../modules/local/coyote/main' // newly added process to ease data import into Coyote3
 
 workflow ADD_TO_DB {
 
@@ -20,7 +20,7 @@ workflow ADD_TO_DB {
         cnvkit_plot     // channel: [optional] [ val(group), val(meta), val(part), file(cnvkit_overview.png) ]
 
     main:
-        ch_coyote_info = Channel.empty() // Gather data for json_INFO listinf output files for export into Coyote
+        ch_coyote_info = Channel.empty() // Gather data for json_INFO listing output files for export into Coyote3
         lc = lowcov.map{ val-> tuple(val[0], val[2] ) }
         lc_d4 = lowcov_d4.map{ val-> tuple(val[0], val[2] ) }
         cnvkit_plot.groupTuple().set { cnvkit_plot_ch }
@@ -54,12 +54,12 @@ workflow ADD_TO_DB {
         COYOTE { vcf.join(optional) }
         // COYOTE_YAML { vcf.join(optional_json) }
         ch_coyote_info_grouped = ch_coyote_info.groupTuple()
-        OUTPUT_FILES ( ch_coyote_info_grouped )
+        OUTPUT_FILES ( ch_coyote_info_grouped ) // creates a json_INFO from the channel ch_coyote_info_grouped
         OUTPUTS_YAML_COYOTE ( vcf.join(OUTPUT_FILES.out.json_INFO) ) 
 
     emit:
         coyotedone = COYOTE.out.coyote_import        // channel: [ val(group), file(coyote) ]
-        //coyotedone = COYOTE_YAML.out.coyote_import   // channel: [ val(group), file(coyote) ]
+        //coyotedone = COYOTE_YAML.out.coyote_import   // channel: [ val(group), file(coyote) ], old way to make the YAML for Coyote3
         coyoteyaml = OUTPUTS_YAML_COYOTE.out.yaml_coyote3 // channel: [ val(group), file(coyote) ]
 }
 

--- a/workflows/common.nf
+++ b/workflows/common.nf
@@ -17,6 +17,7 @@ include { ADD_TO_DB                     } from '../subworkflows/local/add_to_db'
 include { CNV_ANNOTATE                  } from '../subworkflows/local/cnv_annotate'
 include { FUSIONS                       } from '../subworkflows/local/fusions'
 include { CUSTOM_DUMPSOFTWAREVERSIONS   } from '../modules/local/custom/dumpsoftwareversions/main'
+include { OUTPUT_FILES                  } from '../modules/local/coyote/main'
 
 csv = file(params.csv)
 
@@ -41,6 +42,7 @@ Channel
 workflow SPP_COMMON {
 
     ch_versions = Channel.empty()
+    ch_coyoye_info = Channel.empty() // Gather data for .INFO on output files for export into Coyote
 
     // Checks input, creates meta-channel and decides whether data should be downsampled //
     CHECK_INPUT ( Channel.fromPath(csv), params.paired )
@@ -66,6 +68,13 @@ workflow SPP_COMMON {
     )
     .set { ch_qc }
     ch_versions = ch_versions.mix(ch_qc.versions)
+    ch_coyoye_info = ch_coyoye_info
+        .mix(ch_qc.lowcov
+            .filter { item -> item[1] == 'T' }
+            .map {group, type, file -> tuple(group, 'lowcov', file) }) // using directly the naming in coyote yaml for lowcov.bed
+        .mix(ch_qc.lowcov_d4
+            .filter { item -> item[1] == 'T' }
+            .map {group, type, file -> tuple(group, 'cov', file) }) // using directly the naming in coyote yaml for coyote_cov_json
 
     // Create PGx CSV file
     PHARMACOGENOMICS (
@@ -117,6 +126,11 @@ workflow SPP_COMMON {
     )
     .set { ch_cnvcalled }
     ch_versions = ch_versions.mix(ch_cnvcalled.versions)
+    ch_coyoye_info = ch_coyoye_info
+        .mix(ch_cnvcalled.gatcov_plot
+            .map { group, file -> tuple(group, 'cnvprofile_gatk', file) }) // file is modeled.png (preferred for coyote)
+        .mix(ch_cnvcalled.cnvkit_plot
+            .map { group, meta, part, file -> tuple(group, 'cnvprofile_cnvkit', file) }) // file is cnvkit_overview.png (if modeled.png absent)
 
     CNV_ANNOTATE (
         ch_cnvcalled.tumor_vcf,
@@ -125,6 +139,9 @@ workflow SPP_COMMON {
     )
     .set { ch_cnv }
     ch_versions = ch_versions.mix(ch_cnv.versions)
+    ch_coyoye_info = ch_coyoye_info
+        .mix(ch_cnv.s_json
+            .map { group, file -> tuple(group, 'cnv', file) }) // using directly the naming in coyote yaml)
 
 
     FUSIONS (
@@ -134,6 +151,9 @@ workflow SPP_COMMON {
     )
     .set { ch_fusion }
     ch_versions = ch_versions.mix(ch_fusion.versions)
+    ch_coyoye_info = ch_coyoye_info
+        .mix(ch_fusion.fusions
+            .map { group, file -> tuple(group, 'transloc', file) }) // using directly the naming in coyote yaml for merged.annotated.vcf
 
     BIOMARKERS (
         CHECK_INPUT.out.meta,
@@ -143,6 +163,12 @@ workflow SPP_COMMON {
     )
     .set { ch_bio }
     ch_versions = ch_versions.mix(ch_bio.versions)
+    ch_coyoye_info = ch_coyoye_info
+        .mix(ch_bio.biomarkers
+            .map { group, file -> tuple(group, 'biomarkers', file) }) // using directly the naming in coyote yaml for bio.json
+    
+    // Output INFO for Coyoye
+    OUTPUT_FILES(ch_coyoye_info.groupTuple())
 
 
     ADD_TO_DB (
@@ -155,7 +181,8 @@ workflow SPP_COMMON {
         ch_cnvcalled.gatcov_plot,
         ch_fusion.fusions,
         ch_bio.biomarkers,
-        ch_cnvcalled.cnvkit_plot
+        ch_cnvcalled.cnvkit_plot,
+        OUTPUT_FILES.out.json_INFO
     )
 
     CUSTOM_DUMPSOFTWAREVERSIONS (

--- a/workflows/common.nf
+++ b/workflows/common.nf
@@ -17,7 +17,6 @@ include { ADD_TO_DB                     } from '../subworkflows/local/add_to_db'
 include { CNV_ANNOTATE                  } from '../subworkflows/local/cnv_annotate'
 include { FUSIONS                       } from '../subworkflows/local/fusions'
 include { CUSTOM_DUMPSOFTWAREVERSIONS   } from '../modules/local/custom/dumpsoftwareversions/main'
-include { OUTPUT_FILES                  } from '../modules/local/coyote/main'
 
 csv = file(params.csv)
 
@@ -42,7 +41,6 @@ Channel
 workflow SPP_COMMON {
 
     ch_versions = Channel.empty()
-    ch_coyoye_info = Channel.empty() // Gather data for .INFO on output files for export into Coyote
 
     // Checks input, creates meta-channel and decides whether data should be downsampled //
     CHECK_INPUT ( Channel.fromPath(csv), params.paired )
@@ -68,13 +66,6 @@ workflow SPP_COMMON {
     )
     .set { ch_qc }
     ch_versions = ch_versions.mix(ch_qc.versions)
-    ch_coyoye_info = ch_coyoye_info
-        .mix(ch_qc.lowcov
-            .filter { item -> item[1] == 'T' }
-            .map {group, type, file -> tuple(group, 'lowcov', file) }) // using directly the naming in coyote yaml for lowcov.bed
-        .mix(ch_qc.lowcov_d4
-            .filter { item -> item[1] == 'T' }
-            .map {group, type, file -> tuple(group, 'cov', file) }) // using directly the naming in coyote yaml for coyote_cov_json
 
     // Create PGx CSV file
     PHARMACOGENOMICS (
@@ -126,11 +117,6 @@ workflow SPP_COMMON {
     )
     .set { ch_cnvcalled }
     ch_versions = ch_versions.mix(ch_cnvcalled.versions)
-    ch_coyoye_info = ch_coyoye_info
-        .mix(ch_cnvcalled.gatcov_plot
-            .map { group, file -> tuple(group, 'cnvprofile_gatk', file) }) // file is modeled.png (preferred for coyote)
-        .mix(ch_cnvcalled.cnvkit_plot
-            .map { group, meta, part, file -> tuple(group, 'cnvprofile_cnvkit', file) }) // file is cnvkit_overview.png (if modeled.png absent)
 
     CNV_ANNOTATE (
         ch_cnvcalled.tumor_vcf,
@@ -139,9 +125,6 @@ workflow SPP_COMMON {
     )
     .set { ch_cnv }
     ch_versions = ch_versions.mix(ch_cnv.versions)
-    ch_coyoye_info = ch_coyoye_info
-        .mix(ch_cnv.s_json
-            .map { group, file -> tuple(group, 'cnv', file) }) // using directly the naming in coyote yaml)
 
 
     FUSIONS (
@@ -151,9 +134,6 @@ workflow SPP_COMMON {
     )
     .set { ch_fusion }
     ch_versions = ch_versions.mix(ch_fusion.versions)
-    ch_coyoye_info = ch_coyoye_info
-        .mix(ch_fusion.fusions
-            .map { group, file -> tuple(group, 'transloc', file) }) // using directly the naming in coyote yaml for merged.annotated.vcf
 
     BIOMARKERS (
         CHECK_INPUT.out.meta,
@@ -163,12 +143,6 @@ workflow SPP_COMMON {
     )
     .set { ch_bio }
     ch_versions = ch_versions.mix(ch_bio.versions)
-    ch_coyoye_info = ch_coyoye_info
-        .mix(ch_bio.biomarkers
-            .map { group, file -> tuple(group, 'biomarkers', file) }) // using directly the naming in coyote yaml for bio.json
-    
-    // Output INFO for Coyoye
-    OUTPUT_FILES(ch_coyoye_info.groupTuple())
 
 
     ADD_TO_DB (
@@ -181,8 +155,7 @@ workflow SPP_COMMON {
         ch_cnvcalled.gatcov_plot,
         ch_fusion.fusions,
         ch_bio.biomarkers,
-        ch_cnvcalled.cnvkit_plot,
-        OUTPUT_FILES.out.json_INFO
+        ch_cnvcalled.cnvkit_plot
     )
 
     CUSTOM_DUMPSOFTWAREVERSIONS (


### PR DESCRIPTION
<!-- Pull Request Template for SomaticPanelPipeline -->

# Summary
This PR deals with issue #121, simplifying the data import into Coyote3. It replaces the process COYOTE_YAML that echo info into a yaml file and uses FindIndexOf, by a two-step approach, with 1) collection of info for optional data into an intermediate json file and 2) use of the json file by a newly generated python script to create the coyote3 yaml file. 
Modification of:
- add_to_db subworflow: collection and mix of optional data into a ch_coyote_info with their respective yaml label for easier retrieval when writing the yaml file. Inclusion of two new processes OUTPUT_FILES  and OUTPUTS_YAML_COYOTE.
- add_to_db.config to include the two new processes and their publishDir
- coyote module: new processes OUTPUT_FILES (creates a json_INFO from the channel ch_coyote_info)  and OUTPUTS_YAML_COYOTE (use of meta [changed into a meta.json], the json_INFO and finished_vcf (output from SNV_ANNOTATE) to generate the yaml file by a python script (bin/make_coyote_yaml.py).

---

## Type of change
- [ ] Bug fix  
- [ ] Patch / hotfix  
- [x] New feature / enhancement  
- [ ] Refactor / cleanup  
- [ ] Documentation update  


---

## Checklist (author)  

- [x] **CHANGELOG** updated with a clear entry   
- [x] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [x] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [x] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [x] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)  
- [x] New data formats tested for compatibility with **Coyote3**  
- [ ] New data formats tested for compatibility with **GENS**  
- [ ] Documentation updated (README, params, examples, usage)  
- [ ] Containers / tools updated are version-pinned and reproducible  
- [ ] At least one reviewer has tested and approved the code  

---

## Breaking changes
- [x] No breaking changes  
- [ ]  Params/outputs/configs changed (list details in **Summary**)  
- [ ] Output filenames or structure changed (document migration path)  

---

## Testing performed
Pipeline tested with stub-run with profile GMSHem, PARP_inhib, solid.
Pipeline tested by running it with two samples: an unpaired test GMSHem- and a paired solid samples. Old coyote3 yaml and newly generated yaml match. Results of these tests can be found temporarily on the cluster:
- "fs1/julia/results/gmshem/coyote"
- "fs1/julia/results/solid_hg38/coyote"
The new yaml was tested successfully for correct import into Coyote3 for these two samples.

Performed by:  
- [ ] Viktor  
- [ ] Ram  
- [ ] Sailedra 
- [x] Julia

(Add if missing)

---

## Notes for reviewers
 

---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [ ] Sailedra  

(Add if missing)

---

