### PR TITLE
Vh qc workflow

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.2.2
+- Hotfix for indentation for peddy version output
+
 ## 3.2.1
 - fixed the missing versions output emitted from the CONTAMINATION process in vcf_qc
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 ## Changelog ##
 
+## 3.2.3
+- QC: New entry separate from the main SPP entry point.
+  - Calls a minimized pipeline to only get QC from sample
+  - alignment + freebayes calling for QC parameters
+  - should be called from a bjorn workflow for tumors waiting for normals
+
 ## 3.2.2
 - Hotfix for indentation for peddy version output
 

--- a/configs/modules/snv_annotate.config
+++ b/configs/modules/snv_annotate.config
@@ -74,7 +74,7 @@ process {
             overwrite: true,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-
+        ext.when    = !params.qc_only
         ext.args    = { "--assay ${params.markgermline}" }
     }
 

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -732,6 +732,7 @@ profiles {
   qc_overwrite {
     params.vardict = false
     params.tnscope = false
+    params.pindel  = false
     params.qc_only = true
   }
 }

--- a/configs/nextflow.hopper.config
+++ b/configs/nextflow.hopper.config
@@ -42,6 +42,7 @@ params {
   dev                                 = false
   validation                          = false
   testing                             = false
+  qc_only                             = false
   dev_suffix                          = params.dev ? '_dev' : ''
 
   // DEFAULTS //
@@ -726,6 +727,12 @@ profiles {
     params.idSnp_bed_gz               = "${params.refpath}/idSnp/44_rsids.vs.dbsnp_146.hg38.tsv.gz"
     params.idSnp_std_bed_gz           = "${params.refpath}/idSnp/44_sorted_rsids_standard.bed.gz"
     params.header                     = "${params.refpath}/idSnp/header"   
+  }
+
+  qc_overwrite {
+    params.vardict = false
+    params.tnscope = false
+    params.qc_only = true
   }
 }
 

--- a/modules/local/peddy/main.nf
+++ b/modules/local/peddy/main.nf
@@ -26,7 +26,7 @@ process PEDDY {
         peddy --sites hg38 $vcf ${meta.id}.ped --prefix ${prefix}
 
         cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
+        "${task.process}":
             peddy: \$(echo \$(python -m peddy --version 2>&1) | sed 's/^.*peddy, version //')
         END_VERSIONS
         """
@@ -38,7 +38,7 @@ process PEDDY {
         echo $meta > ${prefix}.sex_check.csv
 
         cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
+        "${task.process}":
             peddy: \$(echo \$(python -m peddy --version 2>&1) | sed 's/^.*peddy, version //')
         END_VERSIONS
         """

--- a/workflows/qc_flow.nf
+++ b/workflows/qc_flow.nf
@@ -81,7 +81,12 @@ workflow SPP_QC {
 
     VCF_QC (
         ch_vcf_anno.vep_vcf,
+        ch_vcf_anno.germline_variants,
+        ch_vcf.normal_germline,
+        CHECK_INPUT.out.meta
     )
+    .set { ch_qc_vcf }
+    ch_versions = ch_versions.mix(ch_qc_vcf.versions)
 
     CUSTOM_DUMPSOFTWAREVERSIONS (
         ch_versions.unique().collectFile(name: 'collated_versions.yml'),

--- a/workflows/qc_flow.nf
+++ b/workflows/qc_flow.nf
@@ -61,7 +61,7 @@ workflow SPP_QC {
     ch_versions = ch_versions.mix(ch_qc.versions)
 
     SNV_CALLING ( 
-        ch_mapped.bam_umi.groupTuple(),
+        ch_mapped.bam_umi,
         ch_mapped.bam_dedup,
         beds,
         CHECK_INPUT.out.meta,


### PR DESCRIPTION
# Summary
This PR adds a smaller workflow that can do only QC. This will be helpful for sequenced tumors waiting for their paired normal.

It runs a stripped down version of the common.nf workflow called qc_flow.nf available via -entry QC

It also can addon -profile qc_overwrite to further reduce some processes that a run:
* reduced SNV calling to only freebayes (used for contamination and peddy qc)
* skip alot of the snv-annotation

---

## Type of change
- [ ] Bug fix  
- [ ] Patch / hotfix  
- [x] New feature / enhancement  
- [ ] Refactor / cleanup  
- [ ] Documentation update  


---

## Checklist (author)  

- [ ] **CHANGELOG** updated with a clear entry   
- [ ] **Version bumped** in `configs/nextflow.hopper.config` (if user-facing change, skip if it is an infra only)  
- [ ] Pipeline runs successfully on stubs (`-profile test` or equivalent)  
- [ ] Outputs validated (VCFs, metrics, reports, MultiQC if applicable)  
- [ ] Output from affected processes inspected (`.command.sh`, `.command.log`, `.command.err`, result files in `work/`)  
- [ ] New data formats tested for compatibility with **Coyote3**  
- [ ] New data formats tested for compatibility with **GENS**  
- [ ] Documentation updated (README, params, examples, usage)  
- [ ] Containers / tools updated are version-pinned and reproducible  
- [ ] At least one reviewer has tested and approved the code  

---

## Breaking changes
- [ ] No breaking changes  
- [ ] Params/outputs/configs changed (list details in **Summary**)  
- [ ] Output filenames or structure changed (document migration path)  

---

## Testing performed
Describe what was tested, datasets/profiles used, and results. Attach logs or links if helpful.

Performed by:  
- [x] Viktor  
- [ ] Ram  
- [ ] Sailedra  

(Add if missing)

---

## Notes for reviewers
Mention risk areas, edge cases, or anything needing special attention. 

---

## Review performed by
- [ ] Viktor  
- [ ] Ram  
- [ ] Sailedra  

(Add if missing)

---

## Release notes (draft)
Short, user-facing bullet points for the next release tag.
